### PR TITLE
Remove redundant comment in alias.go.tmpl

### DIFF
--- a/templates/module/alias.go.tmpl
+++ b/templates/module/alias.go.tmpl
@@ -39,5 +39,4 @@ type (
 	Params       = types.Params
 
 	// TODO: Fill out module types
-)TODO: Fill out module types
 )


### PR DESCRIPTION
Remove redundant comment in `templates/module/alias.go.tmpl`

```
)TODO: Fill out module types
```