### PR TITLE
Spike on clone + search & replace

### DIFF
--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -47,6 +47,25 @@ var tutCmd = &cobra.Command{
 	},
 }
 
+var cloneCmd = &cobra.Command{
+	Use:   "clone [cloneUser] [cloneRepo] [user] [repo]",
+	Short: "clone an SDK app and make your own",
+	Args:  cobra.ExactArgs(4),
+	Run: func(cmd *cobra.Command, args []string) {
+		cln := UserRepoArgs{
+			CloneUser: args[0],
+			CloneRepo: args[1],
+			User:      args[2],
+			Repo:      args[3],
+		}
+		err := clone(cln)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+	},
+}
+
 // moduleCmd
 var moduleCmd = &cobra.Command{
 	Use:   "module [user] [repo] [moduleName]",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,6 +41,8 @@ type UserRepoArgs struct {
 	Dir                  string `json:"dir"`
 	User                 string `json:"user"`
 	Repo                 string `json:"repo"`
+	CloneUser            string `json:"cloneUser"`
+	CloneRepo            string `json:"cloneRepo"`
 	NameRaw              string `json:"nameRaw"`
 	NameLowerCase        string `json:"nameLowerCase"`
 	NameCapitalCamelCase string `json:"nameCapitalCamelCase"`
@@ -68,7 +70,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&outputPath, "output-path", "o", "", "Path to output")
 
 	// Commands for scaffolding
-	rootCmd.AddCommand(tutCmd, appCmd, moduleCmd)
+	rootCmd.AddCommand(tutCmd, appCmd, moduleCmd, cloneCmd)
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestClone(t *testing.T) {
+	tmp, err := ioutil.TempDir("", "scaffold-clone-test-")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// defer os.RemoveAll(tmp) // clean up
+	os.Chdir(tmp)
+	err = clone(UserRepoArgs{
+		User:      "username",
+		Repo:      "repository",
+		CloneUser: "cosmos",
+		CloneRepo: "gaia",
+	})
+	require.NoError(t, err)
+}

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/viper v1.5.0
-	github.com/stretchr/testify v1.4.0 // indirect
+	github.com/stretchr/testify v1.4.0
 	golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a // indirect
 	golang.org/x/text v0.3.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -114,6 +114,7 @@ github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DM
 github.com/spf13/viper v1.5.0 h1:GpsTwfsQ27oS/Aha/6d1oD7tpKIqWnOA6tgOX9HHkt4=
 github.com/spf13/viper v1.5.0/go.mod h1:AkYRkVJF8TkSG/xet6PzXX+l39KhhXa2pdqVSxnTcn4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
@@ -138,7 +139,9 @@ golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181220203305-927f97764cc3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190522155817-f3200d17e092 h1:4QSRKanuywn15aTZvI/mIDEgPQpswuFndXpOj3rKEco=
 golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
+golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be h1:vEDujvNQGv4jgYKudGeI/+DAX4Jffq6hpD55MmoEvKs=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
This is a spike on the search and replace version of the scaffold command. Since the tutorial command is essentially cloning the relevant code and replacing the package name with the current users, i wanted to try doing it with search and replace instead of templates. This makes it possible to clone any repo, not just the tutorials, and use it as a starting point to then use other scaffold commands like `module` and eventually `msg`. 

To use just `make install` then try the following command to clone the gaia repo as a starting point:
```
scaffold clone cosmos gaia <yourUserName> <yourDesiredRepoName>
```
This clones the cosmos/gaia repo into a tmp dir, removes the .git dir, replaces all instances of `cosmos/gaia` with `yourUserName/yourDesiredRepoName` then moves the dir into the `cwd/<yourDesiredRepoName>`

Pretty simple / stupid and will need to make a custom version to handle the nameservice and hellochain examples since they are in the same repo nested below the root. But if we want to limit the template use to more robust module and msg creation we can simplify the clone command and use it with any sdk chain as a starting point. This also means we don't need to use templates as sources of truth, which can get messy since we can't actually compile them as templates.