### PR TITLE
Update envPrefix to be consistent with app name 

### DIFF
--- a/templates/lvl-1/cmd/aud/main.go.tmpl
+++ b/templates/lvl-1/cmd/aud/main.go.tmpl
@@ -60,7 +60,7 @@ func main() {
 	server.AddCommands(ctx, cdc, rootCmd, newApp, exportAppStateAndTMValidators)
 
 	// prepare and add flags
-	executor := cli.PrepareBaseCmd(rootCmd, "GA", app.DefaultNodeHome)
+	executor := cli.PrepareBaseCmd(rootCmd, "AU", app.DefaultNodeHome)
 	rootCmd.PersistentFlags().UintVar(&invCheckPeriod, flagInvCheckPeriod,
 		0, "Assert registered invariants every N blocks")
 	err := executor.Execute()


### PR DESCRIPTION
### Changes
- Update `envPrefix` to be consistent with app name

The [Environment Variables](https://github.com/cosmos/gaia/blob/master/docs/validators/security.md#environment-variables) section (from cosmos/gaia) helped me understand how `envPrefix` was applied, and I think it could also help other beginners if it were referenced in a comment.