### PR TITLE
Modify nameservice.md typo

### DIFF
--- a/docs/nameservice.md
+++ b/docs/nameservice.md
@@ -28,6 +28,6 @@ nsd init <moniker>
 nscli keys add validator
 nsd add-genesis-account validator 100000000stake
 nsd gentx --name validator
-nsd collect-gentx
+nsd collect-gentxs
 nsd start
 ```

--- a/docs/nameservice.md
+++ b/docs/nameservice.md
@@ -27,7 +27,7 @@ Once you have done that run the following commands to start a local development 
 nsd init <moniker>
 nscli keys add validator
 nsd add-genesis-account validator 100000000stake
-nsd gentx --name valdiator
+nsd gentx --name validator
 nsd collect-gentx
 nsd start
 ```


### PR DESCRIPTION
Hello.

Modified the contents of the CLI is an issue that could cause confusion for the starter because it contains a typo.