### PR TITLE
fix old sdkerrors import

### DIFF
--- a/templates/module/internal/types/errors.go.tmpl
+++ b/templates/module/internal/types/errors.go.tmpl
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 // Local code type
@@ -20,5 +19,5 @@ const (
 // TODO: Fill out some custom errors for the module
 // You can see how they are constructed below:
 // func ErrInvalid(codespace sdk.CodespaceType) sdk.Error {
-// 	return sdkerrors(codespace, CodeInvalid, "custom error message")
+// 	return sdk.NewError(codespace, CodeInvalid, "custom error message")
 // }


### PR DESCRIPTION
Looks like the path for error import is not this one so when doing some new module the path fails with error:
```
	github.com/cosmos/cosmos-sdk/types/errors: module github.com/cosmos/cosmos-sdk@latest found (v0.37.5), but does not contain package github.com/cosmos/cosmos-sdk/types/errors
```