### PR TITLE
chore: build the project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,15 @@
 # TODO: add versioning
 # TODO: add ldflags for version of sdk
 
+
+
 all: tools install
 
 mod:
 	@go mod tidy
 
 tools:
-	@go get -u github.com/go-bindata/go-bindata/...
+	bash install-bindata.sh
 
 generate: 
 	@go-bindata --pkg cmd -o cmd/bindata.go -prefix "templates/" templates/...

--- a/install-bindata.sh
+++ b/install-bindata.sh
@@ -1,0 +1,6 @@
+go get -u github.com/go-bindata/go-bindata/... 
+cd ${GOPATH}/src/github.com/go-bindata/go-bindata/
+go test
+cd go-bindata
+go build 
+mv go-bindata /usr/local/bin/


### PR DESCRIPTION
The project requires building `go-bindata` for gophers who have not installed it. I tried to add commands to build it in Makefile, but go does not allow building other projects inside a project root folder and makefile fixes the go command to be executed in the project root folder only. Eventually, I had to make a separate bash script that builds `go-bindata` and run it in Makefile. 