### PR TITLE
lvl-max

### DIFF
--- a/docs/app.md
+++ b/docs/app.md
@@ -17,3 +17,4 @@ Global Flags:
 The following starter applications are available:
 
 - [`lvl-1`](./lvl-1.md) -  Auth, Bank, Distribution, Genutil, Genaccounts, Params, Slashing, Staking, Supply
+- [`lvl-max`](./lvl-max.md) -  Auth, Bank, Crisis, Distribution, Evidence, Genutil, Genaccounts, Gov, Mint, Params, Slashing, Staking, Supply, Upgrade

--- a/docs/lvl-max.md
+++ b/docs/lvl-max.md
@@ -1,0 +1,27 @@
+# Level Max
+
+To scaffold out the `lvl-max` app use the following format:
+
+```bash
+scaffold app lvl-max <github user||org> <repoName>
+```
+
+Then just `cd` into the repo folder and:
+
+```bash
+go mod tidy
+make install
+acli --help
+aud --help
+```
+
+Once you have done that run the following commands to start a local development chain:
+
+```bash
+aud init <moniker>
+acli keys add validator
+aud add-genesis-account validator 100000000stake
+aud gentx --name validator
+aud collect-gentxs
+aud start
+```

--- a/docs/lvl-max.md
+++ b/docs/lvl-max.md
@@ -25,3 +25,7 @@ aud gentx --name validator
 aud collect-gentxs
 aud start
 ```
+
+## Contribution
+
+Contributed by [Kimura Yu](https://github.com/KimuraYu45z) , [LCNEM, Inc.](https://github.com/lcnem)

--- a/templates/lvl-max/.golangci.yml.tmpl
+++ b/templates/lvl-max/.golangci.yml.tmpl
@@ -1,0 +1,60 @@
+linters:
+  enable:
+    - bodyclose
+    - deadcode
+    - depguard
+    - dogsled
+    - dupl
+    - errcheck
+    # - funlen
+    # - gochecknoglobals
+    # - gochecknoinits
+    - goconst
+    - gocritic
+    # - gocyclo
+    # - godox
+    - gofmt
+    - goimports
+    - golint
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - interfacer
+    - lll
+    - misspell
+    # - maligned
+    - nakedret
+    - prealloc
+    - scopelint
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    # - unparam
+    - unused
+    - varcheck
+    # - whitespace
+    # - wsl
+    # - gocognit
+
+linters-settings:
+  govet:
+    check-shadowing: true
+  errcheck:
+    # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`;
+    # default is false: such cases aren't reported by default.
+    check-blank: true
+  golint:
+    # minimal confidence for issues, default is 0.8
+    min-confidence: 0
+  prealloc:
+    # XXX: we don't recommend using this linter before doing performance profiling.
+    # For most programs usage of prealloc will be a premature optimization.
+
+    # Report preallocation suggestions only on simple loops that have no returns/breaks/continues/gotos in them.
+    # True by default.
+    simple: false
+    range-loops: true # Report preallocation suggestions on range loops, true by default
+    for-loops: true # Report preallocation suggestions on for loops, false by default

--- a/templates/lvl-max/Makefile.tmpl
+++ b/templates/lvl-max/Makefile.tmpl
@@ -1,0 +1,33 @@
+PACKAGES=$(shell go list ./... | grep -v '/simulation')
+
+VERSION := $(shell echo $(shell git describe --tags) | sed 's/^v//')
+COMMIT := $(shell git log -1 --format='%H')
+
+# TODO: Update the ldflags with the app, client & server names
+ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=NewApp \
+	-X github.com/cosmos/cosmos-sdk/version.ServerName=asd \
+	-X github.com/cosmos/cosmos-sdk/version.ClientName=ascli \
+	-X github.com/cosmos/cosmos-sdk/version.Version=$(VERSION) \
+	-X github.com/cosmos/cosmos-sdk/version.Commit=$(COMMIT) 
+
+BUILD_FLAGS := -ldflags '$(ldflags)'
+
+all: install
+
+install: go.sum
+		go install -mod=readonly $(BUILD_FLAGS) ./cmd/aud
+		go install -mod=readonly $(BUILD_FLAGS) ./cmd/acli
+
+go.sum: go.mod
+		@echo "--> Ensure dependencies have not been modified"
+		GO111MODULE=on go mod verify
+
+# Uncomment when you have some tests
+# test:
+# 	@go test -mod=readonly $(PACKAGES)
+
+# look into .golangci.yml for enabling / disabling linters
+lint:
+	@echo "--> Running linter"
+	@golangci-lint run
+	@go mod verify

--- a/templates/lvl-max/app/app.go.tmpl
+++ b/templates/lvl-max/app/app.go.tmpl
@@ -21,6 +21,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/bank"
   "github.com/cosmos/cosmos-sdk/x/crisis"
 	distr "github.com/cosmos/cosmos-sdk/x/distribution"
+  "github.com/cosmos/cosmos-sdk/x/evidence"
 	"github.com/cosmos/cosmos-sdk/x/genutil"
   "github.com/cosmos/cosmos-sdk/x/gov"
 	"github.com/cosmos/cosmos-sdk/x/mint"
@@ -56,6 +57,7 @@ var (
 		staking.AppModuleBasic{},
     mint.AppModuleBasic{},
 		distr.AppModuleBasic{},
+    gov.NewAppModuleBasic(paramsclient.ProposalHandler, distr.ProposalHandler, upgradeclient.ProposalHandler),
 		params.AppModuleBasic{},
     crisis.AppModuleBasic{},
 		slashing.AppModuleBasic{},

--- a/templates/lvl-max/app/app.go.tmpl
+++ b/templates/lvl-max/app/app.go.tmpl
@@ -1,0 +1,396 @@
+package app
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+
+	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/libs/log"
+	tmos "github.com/tendermint/tendermint/libs/os"
+	dbm "github.com/tendermint/tm-db"
+
+	bam "github.com/cosmos/cosmos-sdk/baseapp"
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/simapp"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	"github.com/cosmos/cosmos-sdk/version"
+	"github.com/cosmos/cosmos-sdk/x/auth"
+	"github.com/cosmos/cosmos-sdk/x/auth/vesting"
+	"github.com/cosmos/cosmos-sdk/x/bank"
+  "github.com/cosmos/cosmos-sdk/x/crisis"
+	distr "github.com/cosmos/cosmos-sdk/x/distribution"
+	"github.com/cosmos/cosmos-sdk/x/genutil"
+  "github.com/cosmos/cosmos-sdk/x/gov"
+	"github.com/cosmos/cosmos-sdk/x/mint"
+	"github.com/cosmos/cosmos-sdk/x/params"
+  paramsclient "github.com/cosmos/cosmos-sdk/x/params/client"
+	"github.com/cosmos/cosmos-sdk/x/slashing"
+	"github.com/cosmos/cosmos-sdk/x/staking"
+	"github.com/cosmos/cosmos-sdk/x/supply"
+  "github.com/cosmos/cosmos-sdk/x/upgrade"
+	upgradeclient "github.com/cosmos/cosmos-sdk/x/upgrade/client"
+)
+
+const appName = "app"
+
+var (
+	// TODO: rename your cli
+
+	// DefaultCLIHome default home directories for the application CLI
+	DefaultCLIHome = os.ExpandEnv("$HOME/.acli")
+
+	// TODO: rename your daemon
+
+	// DefaultNodeHome sets the folder where the applcation data and configuration will be stored
+	DefaultNodeHome = os.ExpandEnv("$HOME/.aud")
+
+	// ModuleBasics The module BasicManager is in charge of setting up basic,
+	// non-dependant module elements, such as codec registration
+	// and genesis verification.
+	ModuleBasics = module.NewBasicManager(
+		genutil.AppModuleBasic{},
+		auth.AppModuleBasic{},
+		bank.AppModuleBasic{},
+		staking.AppModuleBasic{},
+    mint.AppModuleBasic{},
+		distr.AppModuleBasic{},
+		params.AppModuleBasic{},
+    crisis.AppModuleBasic{},
+		slashing.AppModuleBasic{},
+		supply.AppModuleBasic{},
+    upgrade.AppModuleBasic{},
+		evidence.AppModuleBasic{},
+		// TODO: Add your module(s) AppModuleBasic
+	)
+
+	// module account permissions
+	maccPerms = map[string][]string{
+		auth.FeeCollectorName:     nil,
+		distr.ModuleName:          nil,
+    mint.ModuleName:           {supply.Minter},
+		staking.BondedPoolName:    {supply.Burner, supply.Staking},
+		staking.NotBondedPoolName: {supply.Burner, supply.Staking},
+    gov.ModuleName:            {supply.Burner},
+	}
+)
+
+// MakeCodec creates the application codec. The codec is sealed before it is
+// returned.
+func MakeCodec() *codec.Codec {
+	var cdc = codec.New()
+
+	ModuleBasics.RegisterCodec(cdc)
+	vesting.RegisterCodec(cdc)
+	sdk.RegisterCodec(cdc)
+	codec.RegisterCrypto(cdc)
+
+	return cdc.Seal()
+}
+
+// NewApp extended ABCI application
+type NewApp struct {
+	*bam.BaseApp
+	cdc *codec.Codec
+
+	invCheckPeriod uint
+
+	// keys to access the substores
+	keys  map[string]*sdk.KVStoreKey
+	tKeys map[string]*sdk.TransientStoreKey
+
+	// subspaces
+	subspaces map[string]params.Subspace
+
+	// keepers
+	accountKeeper  auth.AccountKeeper
+	bankKeeper     bank.Keeper
+	supplyKeeper   supply.Keeper
+	stakingKeeper  staking.Keeper
+	slashingKeeper slashing.Keeper
+	mintKeeper     mint.Keeper
+	distrKeeper    distr.Keeper
+	govKeeper      gov.Keeper
+	crisisKeeper   crisis.Keeper
+	paramsKeeper   params.Keeper
+	upgradeKeeper  upgrade.Keeper
+	evidenceKeeper evidence.Keeper
+	// TODO: Add your module(s)
+
+	// Module Manager
+	mm *module.Manager
+
+	// simulation manager
+	sm *module.SimulationManager
+}
+
+// verify app interface at compile time
+var _ simapp.App = (*NewApp)(nil)
+
+// New{{.Repo}}App is a constructor function for {{.Repo}}App
+func NewInitApp(
+	logger log.Logger, db dbm.DB, traceStore io.Writer, loadLatest bool,
+	invCheckPeriod uint, skipUpgradeHeights map[int64]bool, baseAppOptions ...func(*bam.BaseApp),
+) *NewApp {
+	// First define the top level codec that will be shared by the different modules
+	cdc := MakeCodec()
+
+	// BaseApp handles interactions with Tendermint through the ABCI protocol
+	bApp := bam.NewBaseApp(appName, logger, db, auth.DefaultTxDecoder(cdc), baseAppOptions...)
+	bApp.SetCommitMultiStoreTracer(traceStore)
+	bApp.SetAppVersion(version.Version)
+
+	// TODO: Add the keys that module requires
+	keys := sdk.NewKVStoreKeys(
+		bam.MainStoreKey, auth.StoreKey, staking.StoreKey,
+		supply.StoreKey, mint.StoreKey, distr.StoreKey, slashing.StoreKey,
+		gov.StoreKey, params.StoreKey, evidence.StoreKey, upgrade.StoreKey,
+	)
+	tKeys := sdk.NewTransientStoreKeys(staking.TStoreKey, params.TStoreKey)
+
+	// Here you initialize your application with the store keys it requires
+	var app = &NewApp{
+		BaseApp:        bApp,
+		cdc:            cdc,
+		invCheckPeriod: invCheckPeriod,
+		keys:           keys,
+		tKeys:          tKeys,
+		subspaces:      make(map[string]params.Subspace),
+	}
+
+	// The ParamsKeeper handles parameter storage for the application
+	app.paramsKeeper = params.NewKeeper(app.cdc, keys[params.StoreKey], tKeys[params.TStoreKey])
+	// Set specific supspaces
+	app.paramsKeeper = params.NewKeeper(app.cdc, keys[params.StoreKey], tKeys[params.TStoreKey])
+	app.subspaces[auth.ModuleName] = app.paramsKeeper.Subspace(auth.DefaultParamspace)
+	app.subspaces[bank.ModuleName] = app.paramsKeeper.Subspace(bank.DefaultParamspace)
+	app.subspaces[staking.ModuleName] = app.paramsKeeper.Subspace(staking.DefaultParamspace)
+	app.subspaces[mint.ModuleName] = app.paramsKeeper.Subspace(mint.DefaultParamspace)
+	app.subspaces[distr.ModuleName] = app.paramsKeeper.Subspace(distr.DefaultParamspace)
+	app.subspaces[slashing.ModuleName] = app.paramsKeeper.Subspace(slashing.DefaultParamspace)
+	app.subspaces[gov.ModuleName] = app.paramsKeeper.Subspace(gov.DefaultParamspace).WithKeyTable(gov.ParamKeyTable())
+	app.subspaces[crisis.ModuleName] = app.paramsKeeper.Subspace(crisis.DefaultParamspace)
+	app.subspaces[evidence.ModuleName] = app.paramsKeeper.Subspace(evidence.DefaultParamspace)
+
+	// The AccountKeeper handles address -> account lookups
+	app.accountKeeper = auth.NewAccountKeeper(
+		app.cdc,
+		keys[auth.StoreKey],
+		app.subspaces[auth.ModuleName],
+		auth.ProtoBaseAccount,
+	)
+
+	// The BankKeeper allows you perform sdk.Coins interactions
+	app.bankKeeper = bank.NewBaseKeeper(
+		app.accountKeeper,
+		app.subspaces[bank.ModuleName],
+		app.ModuleAccountAddrs(),
+	)
+
+	// The SupplyKeeper collects transaction fees and renders them to the fee distribution module
+	app.supplyKeeper = supply.NewKeeper(
+		app.cdc,
+		keys[supply.StoreKey],
+		app.accountKeeper,
+		app.bankKeeper,
+		maccPerms,
+	)
+
+	// The staking keeper
+	stakingKeeper := staking.NewKeeper(
+		app.cdc,
+		keys[staking.StoreKey],
+		app.supplyKeeper,
+		app.subspaces[staking.ModuleName],
+	)
+
+	app.distrKeeper = distr.NewKeeper(
+		app.cdc,
+		keys[distr.StoreKey],
+		app.subspaces[distr.ModuleName],
+		&stakingKeeper,
+		app.supplyKeeper,
+		auth.FeeCollectorName,
+		app.ModuleAccountAddrs(),
+	)
+
+	app.slashingKeeper = slashing.NewKeeper(
+		app.cdc,
+		keys[slashing.StoreKey],
+		&stakingKeeper,
+		app.subspaces[slashing.ModuleName],
+	)
+
+  app.crisisKeeper = crisis.NewKeeper(
+		app.subspaces[crisis.ModuleName], invCheckPeriod, app.supplyKeeper, auth.FeeCollectorName,
+	)
+
+	app.upgradeKeeper = upgrade.NewKeeper(skipUpgradeHeights, keys[upgrade.StoreKey], app.cdc)
+
+  // create evidence keeper with evidence router
+	evidenceKeeper := evidence.NewKeeper(
+		app.cdc, keys[evidence.StoreKey], app.subspaces[evidence.ModuleName], &stakingKeeper, app.slashingKeeper,
+	)
+	evidenceRouter := evidence.NewRouter()
+
+	// TODO: register evidence routes
+	evidenceKeeper.SetRouter(evidenceRouter)
+
+	app.evidenceKeeper = *evidenceKeeper
+
+	// register the proposal types
+	govRouter := gov.NewRouter()
+	govRouter.AddRoute(gov.RouterKey, gov.ProposalHandler).
+		AddRoute(params.RouterKey, params.NewParamChangeProposalHandler(app.paramsKeeper)).
+		AddRoute(distr.RouterKey, distr.NewCommunityPoolSpendProposalHandler(app.distrKeeper)).
+		AddRoute(upgrade.RouterKey, upgrade.NewSoftwareUpgradeProposalHandler(app.upgradeKeeper))
+	app.govKeeper = gov.NewKeeper(
+		app.cdc, keys[gov.StoreKey], app.subspaces[gov.ModuleName],
+		app.supplyKeeper, &stakingKeeper, govRouter,
+	)
+
+	// register the staking hooks
+	// NOTE: stakingKeeper above is passed by reference, so that it will contain these hooks
+	app.stakingKeeper = *stakingKeeper.SetHooks(
+		staking.NewMultiStakingHooks(
+			app.distrKeeper.Hooks(),
+			app.slashingKeeper.Hooks()),
+	)
+
+	// TODO: Add your module(s) keepers
+
+	// NOTE: Any module instantiated in the module manager that is later modified
+	// must be passed by reference here.
+	app.mm = module.NewManager(
+		genutil.NewAppModule(app.accountKeeper, app.stakingKeeper, app.BaseApp.DeliverTx),
+		auth.NewAppModule(app.accountKeeper),
+		bank.NewAppModule(app.bankKeeper, app.accountKeeper),
+		crisis.NewAppModule(&app.crisisKeeper),
+		supply.NewAppModule(app.supplyKeeper, app.accountKeeper),
+		gov.NewAppModule(app.govKeeper, app.accountKeeper, app.supplyKeeper),
+		mint.NewAppModule(app.mintKeeper),
+		slashing.NewAppModule(app.slashingKeeper, app.accountKeeper, app.stakingKeeper),
+		distr.NewAppModule(app.distrKeeper, app.accountKeeper, app.supplyKeeper, app.stakingKeeper),
+		staking.NewAppModule(app.stakingKeeper, app.accountKeeper, app.supplyKeeper),
+		upgrade.NewAppModule(app.upgradeKeeper),
+		evidence.NewAppModule(app.evidenceKeeper),
+		// TODO: Add your module(s)
+		staking.NewAppModule(app.stakingKeeper, app.accountKeeper, app.supplyKeeper),
+	)
+	// During begin block slashing happens after distr.BeginBlocker so that
+	// there is nothing left over in the validator fee pool, so as to keep the
+	// CanWithdrawInvariant invariant.
+
+	app.mm.SetOrderBeginBlockers(distr.ModuleName, slashing.ModuleName)
+	app.mm.SetOrderEndBlockers(staking.ModuleName)
+
+	// Sets the order of Genesis - Order matters, genutil is to always come last
+	// NOTE: The genutils module must occur after staking so that pools are
+	// properly initialized with tokens from genesis accounts.
+	app.mm.SetOrderInitGenesis(
+		distr.ModuleName,
+		staking.ModuleName,
+		auth.ModuleName,
+		bank.ModuleName,
+		slashing.ModuleName,
+    gov.ModuleName,
+    mint.ModuleName,
+		// TODO: Add your module(s)
+		supply.ModuleName,
+    crisis.ModuleName,
+		genutil.ModuleName,
+    evidence.ModuleName,
+	)
+
+	// register all module routes and module queriers
+	app.mm.RegisterRoutes(app.Router(), app.QueryRouter())
+
+	// The initChainer handles translating the genesis.json file into initial state for the network
+	app.SetInitChainer(app.InitChainer)
+	app.SetBeginBlocker(app.BeginBlocker)
+	app.SetEndBlocker(app.EndBlocker)
+
+	// The AnteHandler handles signature verification and transaction pre-processing
+	app.SetAnteHandler(
+		auth.NewAnteHandler(
+			app.accountKeeper,
+			app.supplyKeeper,
+			auth.DefaultSigVerificationGasConsumer,
+		),
+	)
+
+	// initialize stores
+	app.MountKVStores(keys)
+	app.MountTransientStores(tKeys)
+
+	if loadLatest {
+		err := app.LoadLatestVersion(app.keys[bam.MainStoreKey])
+		if err != nil {
+			tmos.Exit(err.Error())
+		}
+	}
+
+	return app
+}
+
+// GenesisState represents chain state at the start of the chain. Any initial state (account balances) are stored here.
+type GenesisState map[string]json.RawMessage
+
+// NewDefaultGenesisState generates the default state for the application.
+func NewDefaultGenesisState() GenesisState {
+	return ModuleBasics.DefaultGenesis()
+}
+
+// InitChainer application update at chain initialization
+func (app *NewApp) InitChainer(ctx sdk.Context, req abci.RequestInitChain) abci.ResponseInitChain {
+	var genesisState simapp.GenesisState
+
+	app.cdc.MustUnmarshalJSON(req.AppStateBytes, &genesisState)
+
+	return app.mm.InitGenesis(ctx, genesisState)
+}
+
+// BeginBlocker application updates every begin block
+func (app *NewApp) BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock) abci.ResponseBeginBlock {
+	return app.mm.BeginBlock(ctx, req)
+}
+
+// EndBlocker application updates every end block
+func (app *NewApp) EndBlocker(ctx sdk.Context, req abci.RequestEndBlock) abci.ResponseEndBlock {
+	return app.mm.EndBlock(ctx, req)
+}
+
+// LoadHeight loads a particular height
+func (app *NewApp) LoadHeight(height int64) error {
+	return app.LoadVersion(height, app.keys[bam.MainStoreKey])
+}
+
+// ModuleAccountAddrs returns all the app's module account addresses.
+func (app *NewApp) ModuleAccountAddrs() map[string]bool {
+	modAccAddrs := make(map[string]bool)
+	for acc := range maccPerms {
+		modAccAddrs[supply.NewModuleAddress(acc).String()] = true
+	}
+
+	return modAccAddrs
+}
+
+// Codec returns the application's sealed codec.
+func (app *NewApp) Codec() *codec.Codec {
+	return app.cdc
+}
+
+// SimulationManager implements the SimulationApp interface
+func (app *NewApp) SimulationManager() *module.SimulationManager {
+	return app.sm
+}
+
+// GetMaccPerms returns a mapping of the application's module account permissions.
+func GetMaccPerms() map[string][]string {
+	modAccPerms := make(map[string][]string)
+	for k, v := range maccPerms {
+		modAccPerms[k] = v
+	}
+	return modAccPerms
+}

--- a/templates/lvl-max/app/app.go.tmpl
+++ b/templates/lvl-max/app/app.go.tmpl
@@ -1,130 +1,130 @@
 package app
 
 import (
-	"encoding/json"
-	"io"
-	"os"
+  "encoding/json"
+  "io"
+  "os"
 
-	abci "github.com/tendermint/tendermint/abci/types"
-	"github.com/tendermint/tendermint/libs/log"
-	tmos "github.com/tendermint/tendermint/libs/os"
-	dbm "github.com/tendermint/tm-db"
+  abci "github.com/tendermint/tendermint/abci/types"
+  "github.com/tendermint/tendermint/libs/log"
+  tmos "github.com/tendermint/tendermint/libs/os"
+  dbm "github.com/tendermint/tm-db"
 
-	bam "github.com/cosmos/cosmos-sdk/baseapp"
-	"github.com/cosmos/cosmos-sdk/codec"
-	"github.com/cosmos/cosmos-sdk/simapp"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/types/module"
-	"github.com/cosmos/cosmos-sdk/version"
-	"github.com/cosmos/cosmos-sdk/x/auth"
-	"github.com/cosmos/cosmos-sdk/x/auth/vesting"
-	"github.com/cosmos/cosmos-sdk/x/bank"
+  bam "github.com/cosmos/cosmos-sdk/baseapp"
+  "github.com/cosmos/cosmos-sdk/codec"
+  "github.com/cosmos/cosmos-sdk/simapp"
+  sdk "github.com/cosmos/cosmos-sdk/types"
+  "github.com/cosmos/cosmos-sdk/types/module"
+  "github.com/cosmos/cosmos-sdk/version"
+  "github.com/cosmos/cosmos-sdk/x/auth"
+  "github.com/cosmos/cosmos-sdk/x/auth/vesting"
+  "github.com/cosmos/cosmos-sdk/x/bank"
   "github.com/cosmos/cosmos-sdk/x/crisis"
-	distr "github.com/cosmos/cosmos-sdk/x/distribution"
+  distr "github.com/cosmos/cosmos-sdk/x/distribution"
   "github.com/cosmos/cosmos-sdk/x/evidence"
-	"github.com/cosmos/cosmos-sdk/x/genutil"
+  "github.com/cosmos/cosmos-sdk/x/genutil"
   "github.com/cosmos/cosmos-sdk/x/gov"
-	"github.com/cosmos/cosmos-sdk/x/mint"
-	"github.com/cosmos/cosmos-sdk/x/params"
+  "github.com/cosmos/cosmos-sdk/x/mint"
+  "github.com/cosmos/cosmos-sdk/x/params"
   paramsclient "github.com/cosmos/cosmos-sdk/x/params/client"
-	"github.com/cosmos/cosmos-sdk/x/slashing"
-	"github.com/cosmos/cosmos-sdk/x/staking"
-	"github.com/cosmos/cosmos-sdk/x/supply"
+  "github.com/cosmos/cosmos-sdk/x/slashing"
+  "github.com/cosmos/cosmos-sdk/x/staking"
+  "github.com/cosmos/cosmos-sdk/x/supply"
   "github.com/cosmos/cosmos-sdk/x/upgrade"
-	upgradeclient "github.com/cosmos/cosmos-sdk/x/upgrade/client"
+  upgradeclient "github.com/cosmos/cosmos-sdk/x/upgrade/client"
 )
 
 const appName = "app"
 
 var (
-	// TODO: rename your cli
+  // TODO: rename your cli
 
-	// DefaultCLIHome default home directories for the application CLI
-	DefaultCLIHome = os.ExpandEnv("$HOME/.acli")
+  // DefaultCLIHome default home directories for the application CLI
+  DefaultCLIHome = os.ExpandEnv("$HOME/.acli")
 
-	// TODO: rename your daemon
+  // TODO: rename your daemon
 
-	// DefaultNodeHome sets the folder where the applcation data and configuration will be stored
-	DefaultNodeHome = os.ExpandEnv("$HOME/.aud")
+  // DefaultNodeHome sets the folder where the applcation data and configuration will be stored
+  DefaultNodeHome = os.ExpandEnv("$HOME/.aud")
 
-	// ModuleBasics The module BasicManager is in charge of setting up basic,
-	// non-dependant module elements, such as codec registration
-	// and genesis verification.
-	ModuleBasics = module.NewBasicManager(
-		genutil.AppModuleBasic{},
-		auth.AppModuleBasic{},
-		bank.AppModuleBasic{},
-		staking.AppModuleBasic{},
+  // ModuleBasics The module BasicManager is in charge of setting up basic,
+  // non-dependant module elements, such as codec registration
+  // and genesis verification.
+  ModuleBasics = module.NewBasicManager(
+    genutil.AppModuleBasic{},
+    auth.AppModuleBasic{},
+    bank.AppModuleBasic{},
+    staking.AppModuleBasic{},
     mint.AppModuleBasic{},
-		distr.AppModuleBasic{},
+    distr.AppModuleBasic{},
     gov.NewAppModuleBasic(paramsclient.ProposalHandler, distr.ProposalHandler, upgradeclient.ProposalHandler),
-		params.AppModuleBasic{},
+    params.AppModuleBasic{},
     crisis.AppModuleBasic{},
-		slashing.AppModuleBasic{},
-		supply.AppModuleBasic{},
+    slashing.AppModuleBasic{},
+    supply.AppModuleBasic{},
     upgrade.AppModuleBasic{},
-		evidence.AppModuleBasic{},
-		// TODO: Add your module(s) AppModuleBasic
-	)
+    evidence.AppModuleBasic{},
+    // TODO: Add your module(s) AppModuleBasic
+  )
 
-	// module account permissions
-	maccPerms = map[string][]string{
-		auth.FeeCollectorName:     nil,
-		distr.ModuleName:          nil,
+  // module account permissions
+  maccPerms = map[string][]string{
+    auth.FeeCollectorName:     nil,
+    distr.ModuleName:          nil,
     mint.ModuleName:           {supply.Minter},
-		staking.BondedPoolName:    {supply.Burner, supply.Staking},
-		staking.NotBondedPoolName: {supply.Burner, supply.Staking},
+    staking.BondedPoolName:    {supply.Burner, supply.Staking},
+    staking.NotBondedPoolName: {supply.Burner, supply.Staking},
     gov.ModuleName:            {supply.Burner},
-	}
+  }
 )
 
 // MakeCodec creates the application codec. The codec is sealed before it is
 // returned.
 func MakeCodec() *codec.Codec {
-	var cdc = codec.New()
+  var cdc = codec.New()
 
-	ModuleBasics.RegisterCodec(cdc)
-	vesting.RegisterCodec(cdc)
-	sdk.RegisterCodec(cdc)
-	codec.RegisterCrypto(cdc)
+  ModuleBasics.RegisterCodec(cdc)
+  vesting.RegisterCodec(cdc)
+  sdk.RegisterCodec(cdc)
+  codec.RegisterCrypto(cdc)
 
-	return cdc.Seal()
+  return cdc.Seal()
 }
 
 // NewApp extended ABCI application
 type NewApp struct {
-	*bam.BaseApp
-	cdc *codec.Codec
+  *bam.BaseApp
+  cdc *codec.Codec
 
-	invCheckPeriod uint
+  invCheckPeriod uint
 
-	// keys to access the substores
-	keys  map[string]*sdk.KVStoreKey
-	tKeys map[string]*sdk.TransientStoreKey
+  // keys to access the substores
+  keys  map[string]*sdk.KVStoreKey
+  tKeys map[string]*sdk.TransientStoreKey
 
-	// subspaces
-	subspaces map[string]params.Subspace
+  // subspaces
+  subspaces map[string]params.Subspace
 
-	// keepers
-	accountKeeper  auth.AccountKeeper
-	bankKeeper     bank.Keeper
-	supplyKeeper   supply.Keeper
-	stakingKeeper  staking.Keeper
-	slashingKeeper slashing.Keeper
-	mintKeeper     mint.Keeper
-	distrKeeper    distr.Keeper
-	govKeeper      gov.Keeper
-	crisisKeeper   crisis.Keeper
-	paramsKeeper   params.Keeper
-	upgradeKeeper  upgrade.Keeper
-	evidenceKeeper evidence.Keeper
-	// TODO: Add your module(s)
+  // keepers
+  accountKeeper  auth.AccountKeeper
+  bankKeeper     bank.Keeper
+  supplyKeeper   supply.Keeper
+  stakingKeeper  staking.Keeper
+  slashingKeeper slashing.Keeper
+  mintKeeper     mint.Keeper
+  distrKeeper    distr.Keeper
+  govKeeper      gov.Keeper
+  crisisKeeper   crisis.Keeper
+  paramsKeeper   params.Keeper
+  upgradeKeeper  upgrade.Keeper
+  evidenceKeeper evidence.Keeper
+  // TODO: Add your module(s)
 
-	// Module Manager
-	mm *module.Manager
+  // Module Manager
+  mm *module.Manager
 
-	// simulation manager
-	sm *module.SimulationManager
+  // simulation manager
+  sm *module.SimulationManager
 }
 
 // verify app interface at compile time
@@ -132,208 +132,209 @@ var _ simapp.App = (*NewApp)(nil)
 
 // New{{.Repo}}App is a constructor function for {{.Repo}}App
 func NewInitApp(
-	logger log.Logger, db dbm.DB, traceStore io.Writer, loadLatest bool,
-	invCheckPeriod uint, skipUpgradeHeights map[int64]bool, baseAppOptions ...func(*bam.BaseApp),
+  logger log.Logger, db dbm.DB, traceStore io.Writer, loadLatest bool,
+  invCheckPeriod uint, skipUpgradeHeights map[int64]bool, baseAppOptions ...func(*bam.BaseApp),
 ) *NewApp {
-	// First define the top level codec that will be shared by the different modules
-	cdc := MakeCodec()
+  // First define the top level codec that will be shared by the different modules
+  cdc := MakeCodec()
 
-	// BaseApp handles interactions with Tendermint through the ABCI protocol
-	bApp := bam.NewBaseApp(appName, logger, db, auth.DefaultTxDecoder(cdc), baseAppOptions...)
-	bApp.SetCommitMultiStoreTracer(traceStore)
-	bApp.SetAppVersion(version.Version)
+  // BaseApp handles interactions with Tendermint through the ABCI protocol
+  bApp := bam.NewBaseApp(appName, logger, db, auth.DefaultTxDecoder(cdc), baseAppOptions...)
+  bApp.SetCommitMultiStoreTracer(traceStore)
+  bApp.SetAppVersion(version.Version)
 
-	// TODO: Add the keys that module requires
-	keys := sdk.NewKVStoreKeys(
-		bam.MainStoreKey, auth.StoreKey, staking.StoreKey,
-		supply.StoreKey, mint.StoreKey, distr.StoreKey, slashing.StoreKey,
-		gov.StoreKey, params.StoreKey, evidence.StoreKey, upgrade.StoreKey,
-	)
-	tKeys := sdk.NewTransientStoreKeys(staking.TStoreKey, params.TStoreKey)
+  // TODO: Add the keys that module requires
+  keys := sdk.NewKVStoreKeys(
+    bam.MainStoreKey, auth.StoreKey, staking.StoreKey,
+    supply.StoreKey, mint.StoreKey, distr.StoreKey, slashing.StoreKey,
+    gov.StoreKey, params.StoreKey, evidence.StoreKey, upgrade.StoreKey,
+  )
+  tKeys := sdk.NewTransientStoreKeys(staking.TStoreKey, params.TStoreKey)
 
-	// Here you initialize your application with the store keys it requires
-	var app = &NewApp{
-		BaseApp:        bApp,
-		cdc:            cdc,
-		invCheckPeriod: invCheckPeriod,
-		keys:           keys,
-		tKeys:          tKeys,
-		subspaces:      make(map[string]params.Subspace),
-	}
+  // Here you initialize your application with the store keys it requires
+  var app = &NewApp{
+    BaseApp:        bApp,
+    cdc:            cdc,
+    invCheckPeriod: invCheckPeriod,
+    keys:           keys,
+    tKeys:          tKeys,
+    subspaces:      make(map[string]params.Subspace),
+  }
 
-	// The ParamsKeeper handles parameter storage for the application
-	app.paramsKeeper = params.NewKeeper(app.cdc, keys[params.StoreKey], tKeys[params.TStoreKey])
-	// Set specific supspaces
-	app.paramsKeeper = params.NewKeeper(app.cdc, keys[params.StoreKey], tKeys[params.TStoreKey])
-	app.subspaces[auth.ModuleName] = app.paramsKeeper.Subspace(auth.DefaultParamspace)
-	app.subspaces[bank.ModuleName] = app.paramsKeeper.Subspace(bank.DefaultParamspace)
-	app.subspaces[staking.ModuleName] = app.paramsKeeper.Subspace(staking.DefaultParamspace)
-	app.subspaces[mint.ModuleName] = app.paramsKeeper.Subspace(mint.DefaultParamspace)
-	app.subspaces[distr.ModuleName] = app.paramsKeeper.Subspace(distr.DefaultParamspace)
-	app.subspaces[slashing.ModuleName] = app.paramsKeeper.Subspace(slashing.DefaultParamspace)
-	app.subspaces[gov.ModuleName] = app.paramsKeeper.Subspace(gov.DefaultParamspace).WithKeyTable(gov.ParamKeyTable())
-	app.subspaces[crisis.ModuleName] = app.paramsKeeper.Subspace(crisis.DefaultParamspace)
-	app.subspaces[evidence.ModuleName] = app.paramsKeeper.Subspace(evidence.DefaultParamspace)
+  // The ParamsKeeper handles parameter storage for the application
+  app.paramsKeeper = params.NewKeeper(app.cdc, keys[params.StoreKey], tKeys[params.TStoreKey])
+  // Set specific supspaces
+  app.paramsKeeper = params.NewKeeper(app.cdc, keys[params.StoreKey], tKeys[params.TStoreKey])
+  app.subspaces[auth.ModuleName] = app.paramsKeeper.Subspace(auth.DefaultParamspace)
+  app.subspaces[bank.ModuleName] = app.paramsKeeper.Subspace(bank.DefaultParamspace)
+  app.subspaces[staking.ModuleName] = app.paramsKeeper.Subspace(staking.DefaultParamspace)
+  app.subspaces[mint.ModuleName] = app.paramsKeeper.Subspace(mint.DefaultParamspace)
+  app.subspaces[distr.ModuleName] = app.paramsKeeper.Subspace(distr.DefaultParamspace)
+  app.subspaces[slashing.ModuleName] = app.paramsKeeper.Subspace(slashing.DefaultParamspace)
+  app.subspaces[gov.ModuleName] = app.paramsKeeper.Subspace(gov.DefaultParamspace).WithKeyTable(gov.ParamKeyTable())
+  app.subspaces[crisis.ModuleName] = app.paramsKeeper.Subspace(crisis.DefaultParamspace)
+  app.subspaces[evidence.ModuleName] = app.paramsKeeper.Subspace(evidence.DefaultParamspace)
 
-	// The AccountKeeper handles address -> account lookups
-	app.accountKeeper = auth.NewAccountKeeper(
-		app.cdc,
-		keys[auth.StoreKey],
-		app.subspaces[auth.ModuleName],
-		auth.ProtoBaseAccount,
-	)
+  // The AccountKeeper handles address -> account lookups
+  app.accountKeeper = auth.NewAccountKeeper(
+    app.cdc,
+    keys[auth.StoreKey],
+    app.subspaces[auth.ModuleName],
+    auth.ProtoBaseAccount,
+  )
 
-	// The BankKeeper allows you perform sdk.Coins interactions
-	app.bankKeeper = bank.NewBaseKeeper(
-		app.accountKeeper,
-		app.subspaces[bank.ModuleName],
-		app.ModuleAccountAddrs(),
-	)
+  // The BankKeeper allows you perform sdk.Coins interactions
+  app.bankKeeper = bank.NewBaseKeeper(
+    app.accountKeeper,
+    app.subspaces[bank.ModuleName],
+    app.ModuleAccountAddrs(),
+  )
 
-	// The SupplyKeeper collects transaction fees and renders them to the fee distribution module
-	app.supplyKeeper = supply.NewKeeper(
-		app.cdc,
-		keys[supply.StoreKey],
-		app.accountKeeper,
-		app.bankKeeper,
-		maccPerms,
-	)
+  // The SupplyKeeper collects transaction fees and renders them to the fee distribution module
+  app.supplyKeeper = supply.NewKeeper(
+    app.cdc,
+    keys[supply.StoreKey],
+    app.accountKeeper,
+    app.bankKeeper,
+    maccPerms,
+  )
 
-	// The staking keeper
-	stakingKeeper := staking.NewKeeper(
-		app.cdc,
-		keys[staking.StoreKey],
-		app.supplyKeeper,
-		app.subspaces[staking.ModuleName],
-	)
+  // The staking keeper
+  stakingKeeper := staking.NewKeeper(
+    app.cdc,
+    keys[staking.StoreKey],
+    app.supplyKeeper,
+    app.subspaces[staking.ModuleName],
+  )
 
-	app.distrKeeper = distr.NewKeeper(
-		app.cdc,
-		keys[distr.StoreKey],
-		app.subspaces[distr.ModuleName],
-		&stakingKeeper,
-		app.supplyKeeper,
-		auth.FeeCollectorName,
-		app.ModuleAccountAddrs(),
-	)
+  app.distrKeeper = distr.NewKeeper(
+    app.cdc,
+    keys[distr.StoreKey],
+    app.subspaces[distr.ModuleName],
+    &stakingKeeper,
+    app.supplyKeeper,
+    auth.FeeCollectorName,
+    app.ModuleAccountAddrs(),
+  )
 
-	app.slashingKeeper = slashing.NewKeeper(
-		app.cdc,
-		keys[slashing.StoreKey],
-		&stakingKeeper,
-		app.subspaces[slashing.ModuleName],
-	)
+  app.slashingKeeper = slashing.NewKeeper(
+    app.cdc,
+    keys[slashing.StoreKey],
+    &stakingKeeper,
+    app.subspaces[slashing.ModuleName],
+  )
 
   app.crisisKeeper = crisis.NewKeeper(
-		app.subspaces[crisis.ModuleName], invCheckPeriod, app.supplyKeeper, auth.FeeCollectorName,
-	)
+    app.subspaces[crisis.ModuleName], invCheckPeriod, app.supplyKeeper, auth.FeeCollectorName,
+  )
 
-	app.upgradeKeeper = upgrade.NewKeeper(skipUpgradeHeights, keys[upgrade.StoreKey], app.cdc)
+  app.upgradeKeeper = upgrade.NewKeeper(skipUpgradeHeights, keys[upgrade.StoreKey], app.cdc)
 
   // create evidence keeper with evidence router
-	evidenceKeeper := evidence.NewKeeper(
-		app.cdc, keys[evidence.StoreKey], app.subspaces[evidence.ModuleName], &stakingKeeper, app.slashingKeeper,
-	)
-	evidenceRouter := evidence.NewRouter()
+  evidenceKeeper := evidence.NewKeeper(
+    app.cdc, keys[evidence.StoreKey], app.subspaces[evidence.ModuleName], &stakingKeeper, app.slashingKeeper,
+  )
+  evidenceRouter := evidence.NewRouter()
 
-	// TODO: register evidence routes
-	evidenceKeeper.SetRouter(evidenceRouter)
+  // TODO: register evidence routes
+  evidenceKeeper.SetRouter(evidenceRouter)
 
-	app.evidenceKeeper = *evidenceKeeper
+  app.evidenceKeeper = *evidenceKeeper
 
-	// register the proposal types
-	govRouter := gov.NewRouter()
-	govRouter.AddRoute(gov.RouterKey, gov.ProposalHandler).
-		AddRoute(params.RouterKey, params.NewParamChangeProposalHandler(app.paramsKeeper)).
-		AddRoute(distr.RouterKey, distr.NewCommunityPoolSpendProposalHandler(app.distrKeeper)).
-		AddRoute(upgrade.RouterKey, upgrade.NewSoftwareUpgradeProposalHandler(app.upgradeKeeper))
-	app.govKeeper = gov.NewKeeper(
-		app.cdc, keys[gov.StoreKey], app.subspaces[gov.ModuleName],
-		app.supplyKeeper, &stakingKeeper, govRouter,
-	)
+  // register the proposal types
+  govRouter := gov.NewRouter()
+  govRouter.AddRoute(gov.RouterKey, gov.ProposalHandler).
+  AddRoute(params.RouterKey, params.NewParamChangeProposalHandler(app.paramsKeeper)).
+  AddRoute(distr.RouterKey, distr.NewCommunityPoolSpendProposalHandler(app.distrKeeper)).
+  AddRoute(upgrade.RouterKey, upgrade.NewSoftwareUpgradeProposalHandler(app.upgradeKeeper))
+  app.govKeeper = gov.NewKeeper(
+    app.cdc, keys[gov.StoreKey], app.subspaces[gov.ModuleName],
+    app.supplyKeeper, &stakingKeeper, govRouter,
+  )
 
-	// register the staking hooks
-	// NOTE: stakingKeeper above is passed by reference, so that it will contain these hooks
-	app.stakingKeeper = *stakingKeeper.SetHooks(
-		staking.NewMultiStakingHooks(
-			app.distrKeeper.Hooks(),
-			app.slashingKeeper.Hooks()),
-	)
+  // register the staking hooks
+  // NOTE: stakingKeeper above is passed by reference, so that it will contain these hooks
+  app.stakingKeeper = *stakingKeeper.SetHooks(
+    staking.NewMultiStakingHooks(
+      app.distrKeeper.Hooks(),
+      app.slashingKeeper.Hooks()
+    ),
+  )
 
-	// TODO: Add your module(s) keepers
+  // TODO: Add your module(s) keepers
 
-	// NOTE: Any module instantiated in the module manager that is later modified
-	// must be passed by reference here.
-	app.mm = module.NewManager(
-		genutil.NewAppModule(app.accountKeeper, app.stakingKeeper, app.BaseApp.DeliverTx),
-		auth.NewAppModule(app.accountKeeper),
-		bank.NewAppModule(app.bankKeeper, app.accountKeeper),
-		crisis.NewAppModule(&app.crisisKeeper),
-		supply.NewAppModule(app.supplyKeeper, app.accountKeeper),
-		gov.NewAppModule(app.govKeeper, app.accountKeeper, app.supplyKeeper),
-		mint.NewAppModule(app.mintKeeper),
-		slashing.NewAppModule(app.slashingKeeper, app.accountKeeper, app.stakingKeeper),
-		distr.NewAppModule(app.distrKeeper, app.accountKeeper, app.supplyKeeper, app.stakingKeeper),
-		staking.NewAppModule(app.stakingKeeper, app.accountKeeper, app.supplyKeeper),
-		upgrade.NewAppModule(app.upgradeKeeper),
-		evidence.NewAppModule(app.evidenceKeeper),
-		// TODO: Add your module(s)
-		staking.NewAppModule(app.stakingKeeper, app.accountKeeper, app.supplyKeeper),
-	)
-	// During begin block slashing happens after distr.BeginBlocker so that
-	// there is nothing left over in the validator fee pool, so as to keep the
-	// CanWithdrawInvariant invariant.
+  // NOTE: Any module instantiated in the module manager that is later modified
+  // must be passed by reference here.
+  app.mm = module.NewManager(
+    genutil.NewAppModule(app.accountKeeper, app.stakingKeeper, app.BaseApp.DeliverTx),
+    auth.NewAppModule(app.accountKeeper),
+    bank.NewAppModule(app.bankKeeper, app.accountKeeper),
+    crisis.NewAppModule(&app.crisisKeeper),
+    supply.NewAppModule(app.supplyKeeper, app.accountKeeper),
+    gov.NewAppModule(app.govKeeper, app.accountKeeper, app.supplyKeeper),
+    mint.NewAppModule(app.mintKeeper),
+    slashing.NewAppModule(app.slashingKeeper, app.accountKeeper, app.stakingKeeper),
+    distr.NewAppModule(app.distrKeeper, app.accountKeeper, app.supplyKeeper, app.stakingKeeper),
+    staking.NewAppModule(app.stakingKeeper, app.accountKeeper, app.supplyKeeper),
+    upgrade.NewAppModule(app.upgradeKeeper),
+    evidence.NewAppModule(app.evidenceKeeper),
+    // TODO: Add your module(s)
+    staking.NewAppModule(app.stakingKeeper, app.accountKeeper, app.supplyKeeper),
+  )
+  // During begin block slashing happens after distr.BeginBlocker so that
+  // there is nothing left over in the validator fee pool, so as to keep the
+  // CanWithdrawInvariant invariant.
 
-	app.mm.SetOrderBeginBlockers(distr.ModuleName, slashing.ModuleName)
-	app.mm.SetOrderEndBlockers(staking.ModuleName)
+  app.mm.SetOrderBeginBlockers(distr.ModuleName, slashing.ModuleName)
+  app.mm.SetOrderEndBlockers(staking.ModuleName)
 
-	// Sets the order of Genesis - Order matters, genutil is to always come last
-	// NOTE: The genutils module must occur after staking so that pools are
-	// properly initialized with tokens from genesis accounts.
-	app.mm.SetOrderInitGenesis(
-		distr.ModuleName,
-		staking.ModuleName,
-		auth.ModuleName,
-		bank.ModuleName,
-		slashing.ModuleName,
+  // Sets the order of Genesis - Order matters, genutil is to always come last
+  // NOTE: The genutils module must occur after staking so that pools are
+  // properly initialized with tokens from genesis accounts.
+  app.mm.SetOrderInitGenesis(
+    distr.ModuleName,
+    staking.ModuleName,
+    auth.ModuleName,
+    bank.ModuleName,
+    slashing.ModuleName,
     gov.ModuleName,
     mint.ModuleName,
-		// TODO: Add your module(s)
-		supply.ModuleName,
+    // TODO: Add your module(s)
+    supply.ModuleName,
     crisis.ModuleName,
-		genutil.ModuleName,
+    genutil.ModuleName,
     evidence.ModuleName,
-	)
+  )
 
-	// register all module routes and module queriers
-	app.mm.RegisterRoutes(app.Router(), app.QueryRouter())
+  // register all module routes and module queriers
+  app.mm.RegisterRoutes(app.Router(), app.QueryRouter())
 
-	// The initChainer handles translating the genesis.json file into initial state for the network
-	app.SetInitChainer(app.InitChainer)
-	app.SetBeginBlocker(app.BeginBlocker)
-	app.SetEndBlocker(app.EndBlocker)
+  // The initChainer handles translating the genesis.json file into initial state for the network
+  app.SetInitChainer(app.InitChainer)
+  app.SetBeginBlocker(app.BeginBlocker)
+  app.SetEndBlocker(app.EndBlocker)
 
-	// The AnteHandler handles signature verification and transaction pre-processing
-	app.SetAnteHandler(
-		auth.NewAnteHandler(
-			app.accountKeeper,
-			app.supplyKeeper,
-			auth.DefaultSigVerificationGasConsumer,
-		),
-	)
+  // The AnteHandler handles signature verification and transaction pre-processing
+  app.SetAnteHandler(
+    auth.NewAnteHandler(
+      app.accountKeeper,
+      app.supplyKeeper,
+      auth.DefaultSigVerificationGasConsumer,
+    ),
+  )
 
-	// initialize stores
-	app.MountKVStores(keys)
-	app.MountTransientStores(tKeys)
+  // initialize stores
+  app.MountKVStores(keys)
+  app.MountTransientStores(tKeys)
 
-	if loadLatest {
-		err := app.LoadLatestVersion(app.keys[bam.MainStoreKey])
-		if err != nil {
-			tmos.Exit(err.Error())
-		}
-	}
+  if loadLatest {
+    err := app.LoadLatestVersion(app.keys[bam.MainStoreKey])
+    if err != nil {
+      tmos.Exit(err.Error())
+    }
+  }
 
-	return app
+  return app
 }
 
 // GenesisState represents chain state at the start of the chain. Any initial state (account balances) are stored here.
@@ -341,58 +342,58 @@ type GenesisState map[string]json.RawMessage
 
 // NewDefaultGenesisState generates the default state for the application.
 func NewDefaultGenesisState() GenesisState {
-	return ModuleBasics.DefaultGenesis()
+  return ModuleBasics.DefaultGenesis()
 }
 
 // InitChainer application update at chain initialization
 func (app *NewApp) InitChainer(ctx sdk.Context, req abci.RequestInitChain) abci.ResponseInitChain {
-	var genesisState simapp.GenesisState
+  var genesisState simapp.GenesisState
 
-	app.cdc.MustUnmarshalJSON(req.AppStateBytes, &genesisState)
+  app.cdc.MustUnmarshalJSON(req.AppStateBytes, &genesisState)
 
-	return app.mm.InitGenesis(ctx, genesisState)
+  return app.mm.InitGenesis(ctx, genesisState)
 }
 
 // BeginBlocker application updates every begin block
 func (app *NewApp) BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock) abci.ResponseBeginBlock {
-	return app.mm.BeginBlock(ctx, req)
+  return app.mm.BeginBlock(ctx, req)
 }
 
 // EndBlocker application updates every end block
 func (app *NewApp) EndBlocker(ctx sdk.Context, req abci.RequestEndBlock) abci.ResponseEndBlock {
-	return app.mm.EndBlock(ctx, req)
+  return app.mm.EndBlock(ctx, req)
 }
 
 // LoadHeight loads a particular height
 func (app *NewApp) LoadHeight(height int64) error {
-	return app.LoadVersion(height, app.keys[bam.MainStoreKey])
+  return app.LoadVersion(height, app.keys[bam.MainStoreKey])
 }
 
 // ModuleAccountAddrs returns all the app's module account addresses.
 func (app *NewApp) ModuleAccountAddrs() map[string]bool {
-	modAccAddrs := make(map[string]bool)
-	for acc := range maccPerms {
-		modAccAddrs[supply.NewModuleAddress(acc).String()] = true
-	}
+  modAccAddrs := make(map[string]bool)
+  for acc := range maccPerms {
+    modAccAddrs[supply.NewModuleAddress(acc).String()] = true
+  }
 
-	return modAccAddrs
+  return modAccAddrs
 }
 
 // Codec returns the application's sealed codec.
 func (app *NewApp) Codec() *codec.Codec {
-	return app.cdc
+  return app.cdc
 }
 
 // SimulationManager implements the SimulationApp interface
 func (app *NewApp) SimulationManager() *module.SimulationManager {
-	return app.sm
+  return app.sm
 }
 
 // GetMaccPerms returns a mapping of the application's module account permissions.
 func GetMaccPerms() map[string][]string {
-	modAccPerms := make(map[string][]string)
-	for k, v := range maccPerms {
-		modAccPerms[k] = v
-	}
-	return modAccPerms
+  modAccPerms := make(map[string][]string)
+  for k, v := range maccPerms {
+    modAccPerms[k] = v
+  }
+  return modAccPerms
 }

--- a/templates/lvl-max/app/app.go.tmpl
+++ b/templates/lvl-max/app/app.go.tmpl
@@ -257,7 +257,7 @@ func NewInitApp(
   app.stakingKeeper = *stakingKeeper.SetHooks(
     staking.NewMultiStakingHooks(
       app.distrKeeper.Hooks(),
-      app.slashingKeeper.Hooks()
+      app.slashingKeeper.Hooks(),
     ),
   )
 

--- a/templates/lvl-max/app/app.go.tmpl
+++ b/templates/lvl-max/app/app.go.tmpl
@@ -323,6 +323,24 @@ func NewInitApp(
     ),
   )
 
+  // create the simulation manager and define the order of the modules for deterministic simulations
+	//
+	// NOTE: This is not required for apps that don't use the simulator for fuzz testing
+	// transactions.
+	app.sm = module.NewSimulationManager(
+		auth.NewAppModule(app.accountKeeper),
+		bank.NewAppModule(app.bankKeeper, app.accountKeeper),
+		supply.NewAppModule(app.supplyKeeper, app.accountKeeper),
+		gov.NewAppModule(app.govKeeper, app.accountKeeper, app.supplyKeeper),
+		mint.NewAppModule(app.mintKeeper),
+		distr.NewAppModule(app.distrKeeper, app.accountKeeper, app.supplyKeeper, app.stakingKeeper),
+		staking.NewAppModule(app.stakingKeeper, app.accountKeeper, app.supplyKeeper),
+		slashing.NewAppModule(app.slashingKeeper, app.accountKeeper, app.stakingKeeper),
+		// TODO: Add your module(s)
+	)
+
+	app.sm.RegisterStoreDecoders()
+
   // initialize stores
   app.MountKVStores(keys)
   app.MountTransientStores(tKeys)

--- a/templates/lvl-max/app/export.go.tmpl
+++ b/templates/lvl-max/app/export.go.tmpl
@@ -1,0 +1,169 @@
+package app
+
+import (
+	"encoding/json"
+	"log"
+
+	abci "github.com/tendermint/tendermint/abci/types"
+	tmtypes "github.com/tendermint/tendermint/types"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/slashing"
+	"github.com/cosmos/cosmos-sdk/x/staking"
+)
+
+// ExportAppStateAndValidators exports the state of the application for a genesis
+// file.
+func (app *NewApp) ExportAppStateAndValidators(
+	forZeroHeight bool, jailWhiteList []string,
+) (appState json.RawMessage, validators []tmtypes.GenesisValidator, err error) {
+
+	// as if they could withdraw from the start of the next block
+	ctx := app.NewContext(true, abci.Header{Height: app.LastBlockHeight()})
+
+	if forZeroHeight {
+		app.prepForZeroHeightGenesis(ctx, jailWhiteList)
+	}
+
+	genState := app.mm.ExportGenesis(ctx)
+	appState, err = codec.MarshalJSONIndent(app.cdc, genState)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	validators = staking.WriteValidators(ctx, app.stakingKeeper)
+	return appState, validators, nil
+}
+
+// prepare for fresh start at zero height
+// NOTE zero height genesis is a temporary feature which will be deprecated
+//      in favour of export at a block height
+func (app *NewApp) prepForZeroHeightGenesis(ctx sdk.Context, jailWhiteList []string) {
+	applyWhiteList := false
+
+	//Check if there is a whitelist
+	if len(jailWhiteList) > 0 {
+		applyWhiteList = true
+	}
+
+	whiteListMap := make(map[string]bool)
+
+	for _, addr := range jailWhiteList {
+		_, err := sdk.ValAddressFromBech32(addr)
+		if err != nil {
+			log.Fatal(err)
+		}
+		whiteListMap[addr] = true
+	}
+
+	/* Handle fee distribution state. */
+
+	// withdraw all validator commission
+	app.stakingKeeper.IterateValidators(ctx, func(_ int64, val staking.ValidatorI) (stop bool) {
+		_, err := app.distrKeeper.WithdrawValidatorCommission(ctx, val.GetOperator())
+		if err != nil {
+			log.Fatal(err)
+		}
+		return false
+	})
+
+	// withdraw all delegator rewards
+	dels := app.stakingKeeper.GetAllDelegations(ctx)
+	for _, delegation := range dels {
+		_, err := app.distrKeeper.WithdrawDelegationRewards(ctx, delegation.DelegatorAddress, delegation.ValidatorAddress)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	// clear validator slash events
+	app.distrKeeper.DeleteAllValidatorSlashEvents(ctx)
+
+	// clear validator historical rewards
+	app.distrKeeper.DeleteAllValidatorHistoricalRewards(ctx)
+
+	// set context height to zero
+	height := ctx.BlockHeight()
+	ctx = ctx.WithBlockHeight(0)
+
+	// reinitialize all validators
+	app.stakingKeeper.IterateValidators(ctx, func(_ int64, val staking.ValidatorI) (stop bool) {
+
+		// donate any unwithdrawn outstanding reward fraction tokens to the community pool
+		scraps := app.distrKeeper.GetValidatorOutstandingRewards(ctx, val.GetOperator())
+		feePool := app.distrKeeper.GetFeePool(ctx)
+		feePool.CommunityPool = feePool.CommunityPool.Add(scraps...)
+		app.distrKeeper.SetFeePool(ctx, feePool)
+
+		app.distrKeeper.Hooks().AfterValidatorCreated(ctx, val.GetOperator())
+		return false
+	})
+
+	// reinitialize all delegations
+	for _, del := range dels {
+		app.distrKeeper.Hooks().BeforeDelegationCreated(ctx, del.DelegatorAddress, del.ValidatorAddress)
+		app.distrKeeper.Hooks().AfterDelegationModified(ctx, del.DelegatorAddress, del.ValidatorAddress)
+	}
+
+	// reset context height
+	ctx = ctx.WithBlockHeight(height)
+
+	/* Handle staking state. */
+
+	// iterate through redelegations, reset creation height
+	app.stakingKeeper.IterateRedelegations(ctx, func(_ int64, red staking.Redelegation) (stop bool) {
+		for i := range red.Entries {
+			red.Entries[i].CreationHeight = 0
+		}
+		app.stakingKeeper.SetRedelegation(ctx, red)
+		return false
+	})
+
+	// iterate through unbonding delegations, reset creation height
+	app.stakingKeeper.IterateUnbondingDelegations(ctx, func(_ int64, ubd staking.UnbondingDelegation) (stop bool) {
+		for i := range ubd.Entries {
+			ubd.Entries[i].CreationHeight = 0
+		}
+		app.stakingKeeper.SetUnbondingDelegation(ctx, ubd)
+		return false
+	})
+
+	// Iterate through validators by power descending, reset bond heights, and
+	// update bond intra-tx counters.
+	store := ctx.KVStore(app.keys[staking.StoreKey])
+	iter := sdk.KVStoreReversePrefixIterator(store, staking.ValidatorsKey)
+	counter := int16(0)
+
+	for ; iter.Valid(); iter.Next() {
+		addr := sdk.ValAddress(iter.Key()[1:])
+		validator, found := app.stakingKeeper.GetValidator(ctx, addr)
+		if !found {
+			panic("expected validator, not found")
+		}
+
+		validator.UnbondingHeight = 0
+		if applyWhiteList && !whiteListMap[addr.String()] {
+			validator.Jailed = true
+		}
+
+		app.stakingKeeper.SetValidator(ctx, validator)
+		counter++
+	}
+
+	iter.Close()
+
+	_ = app.stakingKeeper.ApplyAndReturnValidatorSetUpdates(ctx)
+
+	/* Handle slashing state. */
+
+	// reset start height on signing infos
+	app.slashingKeeper.IterateValidatorSigningInfos(
+		ctx,
+		func(addr sdk.ConsAddress, info slashing.ValidatorSigningInfo) (stop bool) {
+			info.StartHeight = 0
+			app.slashingKeeper.SetValidatorSigningInfo(ctx, addr, info)
+			return false
+		},
+	)
+}

--- a/templates/lvl-max/app/sim_test.go.tmpl
+++ b/templates/lvl-max/app/sim_test.go.tmpl
@@ -154,6 +154,7 @@ func TestAppImportExport(t *testing.T) {
 		{app.keys[supply.StoreKey], newApp.keys[supply.StoreKey], [][]byte{}},
 		{app.keys[params.StoreKey], newApp.keys[params.StoreKey], [][]byte{}},
 		{app.keys[gov.StoreKey], newApp.keys[gov.StoreKey], [][]byte{}},
+    // TODO: Add your module(s)
 	}
 
 	for _, skp := range storeKeysPrefixes {

--- a/templates/lvl-max/app/sim_test.go.tmpl
+++ b/templates/lvl-max/app/sim_test.go.tmpl
@@ -1,0 +1,295 @@
+package app
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/libs/log"
+	dbm "github.com/tendermint/tm-db"
+
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	"github.com/cosmos/cosmos-sdk/simapp"
+	"github.com/cosmos/cosmos-sdk/simapp/helpers"
+	"github.com/cosmos/cosmos-sdk/store"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth"
+	distr "github.com/cosmos/cosmos-sdk/x/distribution"
+	"github.com/cosmos/cosmos-sdk/x/gov"
+	"github.com/cosmos/cosmos-sdk/x/mint"
+	"github.com/cosmos/cosmos-sdk/x/params"
+	"github.com/cosmos/cosmos-sdk/x/simulation"
+	"github.com/cosmos/cosmos-sdk/x/slashing"
+	"github.com/cosmos/cosmos-sdk/x/staking"
+	"github.com/cosmos/cosmos-sdk/x/supply"
+)
+
+func init() {
+	simapp.GetSimulatorFlags()
+}
+
+type StoreKeysPrefixes struct {
+	A        sdk.StoreKey
+	B        sdk.StoreKey
+	Prefixes [][]byte
+}
+
+// fauxMerkleModeOpt returns a BaseApp option to use a dbStoreAdapter instead of
+// an IAVLStore for faster simulation speed.
+func fauxMerkleModeOpt(bapp *baseapp.BaseApp) {
+	bapp.SetFauxMerkleMode()
+}
+
+// interBlockCacheOpt returns a BaseApp option function that sets the persistent
+// inter-block write-through cache.
+func interBlockCacheOpt() func(*baseapp.BaseApp) {
+	return baseapp.SetInterBlockCache(store.NewCommitKVStoreCacheManager())
+}
+
+func TestFullAppSimulation(t *testing.T) {
+	config, db, dir, logger, skip, err := simapp.SetupSimulation("leveldb-app-sim", "Simulation")
+	if skip {
+		t.Skip("skipping application simulation")
+	}
+	require.NoError(t, err, "simulation setup failed")
+
+	defer func() {
+		db.Close()
+		require.NoError(t, os.RemoveAll(dir))
+	}()
+
+	app := NewInitApp(logger, db, nil, true, simapp.FlagPeriodValue, map[int64]bool{}, fauxMerkleModeOpt)
+	require.Equal(t, appName, app.Name())
+
+	// run randomized simulation
+	_, simParams, simErr := simulation.SimulateFromSeed(
+		t, os.Stdout, app.BaseApp, simapp.AppStateFn(app.Codec(), app.SimulationManager()),
+		simapp.SimulationOperations(app, app.Codec(), config),
+		app.ModuleAccountAddrs(), config,
+	)
+
+	// export state and simParams before the simulation error is checked
+	err = simapp.CheckExportSimulation(app, config, simParams)
+	require.NoError(t, err)
+	require.NoError(t, simErr)
+
+	if config.Commit {
+		simapp.PrintStats(db)
+	}
+}
+
+func TestAppImportExport(t *testing.T) {
+	config, db, dir, logger, skip, err := simapp.SetupSimulation("leveldb-app-sim", "Simulation")
+	if skip {
+		t.Skip("skipping application import/export simulation")
+	}
+	require.NoError(t, err, "simulation setup failed")
+
+	defer func() {
+		db.Close()
+		require.NoError(t, os.RemoveAll(dir))
+	}()
+
+	app := NewInitApp(logger, db, nil, true, simapp.FlagPeriodValue, map[int64]bool{}, fauxMerkleModeOpt)
+	require.Equal(t, appName, app.Name())
+
+	// Run randomized simulation
+	_, simParams, simErr := simulation.SimulateFromSeed(
+		t, os.Stdout, app.BaseApp, simapp.AppStateFn(app.Codec(), app.SimulationManager()),
+		simapp.SimulationOperations(app, app.Codec(), config),
+		app.ModuleAccountAddrs(), config,
+	)
+
+	// export state and simParams before the simulation error is checked
+	err = simapp.CheckExportSimulation(app, config, simParams)
+	require.NoError(t, err)
+	require.NoError(t, simErr)
+
+	if config.Commit {
+		simapp.PrintStats(db)
+	}
+
+	fmt.Printf("exporting genesis...\n")
+
+	appState, _, err := app.ExportAppStateAndValidators(false, []string{})
+	require.NoError(t, err)
+
+	fmt.Printf("importing genesis...\n")
+
+	_, newDB, newDir, _, _, err := simapp.SetupSimulation("leveldb-app-sim-2", "Simulation-2")
+	require.NoError(t, err, "simulation setup failed")
+
+	defer func() {
+		newDB.Close()
+		require.NoError(t, os.RemoveAll(newDir))
+	}()
+
+	newApp := NewInitApp(log.NewNopLogger(), newDB, nil, true, simapp.FlagPeriodValue, map[int64]bool{}, fauxMerkleModeOpt)
+	require.Equal(t, appName, newApp.Name())
+
+	var genesisState GenesisState
+	err = app.Codec().UnmarshalJSON(appState, &genesisState)
+	require.NoError(t, err)
+
+	ctxA := app.NewContext(true, abci.Header{Height: app.LastBlockHeight()})
+	ctxB := newApp.NewContext(true, abci.Header{Height: app.LastBlockHeight()})
+	newApp.mm.InitGenesis(ctxB, genesisState)
+
+	fmt.Printf("comparing stores...\n")
+
+	storeKeysPrefixes := []StoreKeysPrefixes{
+		{app.keys[baseapp.MainStoreKey], newApp.keys[baseapp.MainStoreKey], [][]byte{}},
+		{app.keys[auth.StoreKey], newApp.keys[auth.StoreKey], [][]byte{}},
+		{app.keys[staking.StoreKey], newApp.keys[staking.StoreKey],
+			[][]byte{
+				staking.UnbondingQueueKey, staking.RedelegationQueueKey, staking.ValidatorQueueKey,
+			}}, // ordering may change but it doesn't matter
+		{app.keys[slashing.StoreKey], newApp.keys[slashing.StoreKey], [][]byte{}},
+		{app.keys[mint.StoreKey], newApp.keys[mint.StoreKey], [][]byte{}},
+		{app.keys[distr.StoreKey], newApp.keys[distr.StoreKey], [][]byte{}},
+		{app.keys[supply.StoreKey], newApp.keys[supply.StoreKey], [][]byte{}},
+		{app.keys[params.StoreKey], newApp.keys[params.StoreKey], [][]byte{}},
+		{app.keys[gov.StoreKey], newApp.keys[gov.StoreKey], [][]byte{}},
+	}
+
+	for _, skp := range storeKeysPrefixes {
+		storeA := ctxA.KVStore(skp.A)
+		storeB := ctxB.KVStore(skp.B)
+
+		failedKVAs, failedKVBs := sdk.DiffKVStores(storeA, storeB, skp.Prefixes)
+		require.Equal(t, len(failedKVAs), len(failedKVBs), "unequal sets of key-values to compare")
+
+		fmt.Printf("compared %d key/value pairs between %s and %s\n", len(failedKVAs), skp.A, skp.B)
+		require.Equal(t, len(failedKVAs), 0, simapp.GetSimulationLog(skp.A.Name(), app.SimulationManager().StoreDecoders, app.Codec(), failedKVAs, failedKVBs))
+	}
+}
+
+func TestAppSimulationAfterImport(t *testing.T) {
+	config, db, dir, logger, skip, err := simapp.SetupSimulation("leveldb-app-sim", "Simulation")
+	if skip {
+		t.Skip("skipping application simulation after import")
+	}
+	require.NoError(t, err, "simulation setup failed")
+
+	defer func() {
+		db.Close()
+		require.NoError(t, os.RemoveAll(dir))
+	}()
+
+	app := NewInitApp(logger, db, nil, true, simapp.FlagPeriodValue, map[int64]bool{}, fauxMerkleModeOpt)
+	require.Equal(t, appName, app.Name())
+
+	// Run randomized simulation
+	stopEarly, simParams, simErr := simulation.SimulateFromSeed(
+		t, os.Stdout, app.BaseApp, simapp.AppStateFn(app.Codec(), app.SimulationManager()),
+		simapp.SimulationOperations(app, app.Codec(), config),
+		app.ModuleAccountAddrs(), config,
+	)
+
+	// export state and simParams before the simulation error is checked
+	err = simapp.CheckExportSimulation(app, config, simParams)
+	require.NoError(t, err)
+	require.NoError(t, simErr)
+
+	if config.Commit {
+		simapp.PrintStats(db)
+	}
+
+	if stopEarly {
+		fmt.Println("can't export or import a zero-validator genesis, exiting test...")
+		return
+	}
+
+	fmt.Printf("exporting genesis...\n")
+
+	appState, _, err := app.ExportAppStateAndValidators(true, []string{})
+	require.NoError(t, err)
+
+	fmt.Printf("importing genesis...\n")
+
+	_, newDB, newDir, _, _, err := simapp.SetupSimulation("leveldb-app-sim-2", "Simulation-2")
+	require.NoError(t, err, "simulation setup failed")
+
+	defer func() {
+		newDB.Close()
+		require.NoError(t, os.RemoveAll(newDir))
+	}()
+
+	newApp := NewInitApp(log.NewNopLogger(), newDB, nil, true, simapp.FlagPeriodValue, map[int64]bool{}, fauxMerkleModeOpt)
+	require.Equal(t, appName, newApp.Name())
+
+	newApp.InitChain(abci.RequestInitChain{
+		AppStateBytes: appState,
+	})
+
+	_, _, err = simulation.SimulateFromSeed(
+		t, os.Stdout, newApp.BaseApp, simapp.AppStateFn(app.Codec(), app.SimulationManager()),
+		simapp.SimulationOperations(newApp, newApp.Codec(), config),
+		newApp.ModuleAccountAddrs(), config,
+	)
+	require.NoError(t, err)
+}
+
+func TestAppStateDeterminism(t *testing.T) {
+	if !simapp.FlagEnabledValue {
+		t.Skip("skipping application simulation")
+	}
+
+	config := simapp.NewConfigFromFlags()
+	config.InitialBlockHeight = 1
+	config.ExportParamsPath = ""
+	config.OnOperation = false
+	config.AllInvariants = false
+	config.ChainID = helpers.SimAppChainID
+
+	numSeeds := 3
+	numTimesToRunPerSeed := 5
+	appHashList := make([]json.RawMessage, numTimesToRunPerSeed)
+
+	for i := 0; i < numSeeds; i++ {
+		config.Seed = rand.Int63()
+
+		for j := 0; j < numTimesToRunPerSeed; j++ {
+			var logger log.Logger
+			if simapp.FlagVerboseValue {
+				logger = log.TestingLogger()
+			} else {
+				logger = log.NewNopLogger()
+			}
+
+			db := dbm.NewMemDB()
+
+			app := NewInitApp(logger, db, nil, true, simapp.FlagPeriodValue, map[int64]bool{}, interBlockCacheOpt())
+
+			fmt.Printf(
+				"running non-determinism simulation; seed %d: %d/%d, attempt: %d/%d\n",
+				config.Seed, i+1, numSeeds, j+1, numTimesToRunPerSeed,
+			)
+
+			_, _, err := simulation.SimulateFromSeed(
+				t, os.Stdout, app.BaseApp, simapp.AppStateFn(app.Codec(), app.SimulationManager()),
+				simapp.SimulationOperations(app, app.Codec(), config),
+				app.ModuleAccountAddrs(), config,
+			)
+			require.NoError(t, err)
+
+			if config.Commit {
+				simapp.PrintStats(db)
+			}
+
+			appHash := app.LastCommitID().Hash
+			appHashList[j] = appHash
+
+			if j != 0 {
+				require.Equal(
+					t, appHashList[0], appHashList[j],
+					"non-determinism in seed %d: %d/%d, attempt: %d/%d\n", config.Seed, i+1, numSeeds, j+1, numTimesToRunPerSeed,
+				)
+			}
+		}
+	}
+}

--- a/templates/lvl-max/app/sim_test.go.tmpl
+++ b/templates/lvl-max/app/sim_test.go.tmpl
@@ -1,296 +1,296 @@
 package app
 
 import (
-	"encoding/json"
-	"fmt"
-	"math/rand"
-	"os"
-	"testing"
+  "encoding/json"
+  "fmt"
+  "math/rand"
+  "os"
+  "testing"
 
-	"github.com/stretchr/testify/require"
-	abci "github.com/tendermint/tendermint/abci/types"
-	"github.com/tendermint/tendermint/libs/log"
-	dbm "github.com/tendermint/tm-db"
+  "github.com/stretchr/testify/require"
+  abci "github.com/tendermint/tendermint/abci/types"
+  "github.com/tendermint/tendermint/libs/log"
+  dbm "github.com/tendermint/tm-db"
 
-	"github.com/cosmos/cosmos-sdk/baseapp"
-	"github.com/cosmos/cosmos-sdk/simapp"
-	"github.com/cosmos/cosmos-sdk/simapp/helpers"
-	"github.com/cosmos/cosmos-sdk/store"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/x/auth"
-	distr "github.com/cosmos/cosmos-sdk/x/distribution"
-	"github.com/cosmos/cosmos-sdk/x/gov"
-	"github.com/cosmos/cosmos-sdk/x/mint"
-	"github.com/cosmos/cosmos-sdk/x/params"
-	"github.com/cosmos/cosmos-sdk/x/simulation"
-	"github.com/cosmos/cosmos-sdk/x/slashing"
-	"github.com/cosmos/cosmos-sdk/x/staking"
-	"github.com/cosmos/cosmos-sdk/x/supply"
+  "github.com/cosmos/cosmos-sdk/baseapp"
+  "github.com/cosmos/cosmos-sdk/simapp"
+  "github.com/cosmos/cosmos-sdk/simapp/helpers"
+  "github.com/cosmos/cosmos-sdk/store"
+  sdk "github.com/cosmos/cosmos-sdk/types"
+  "github.com/cosmos/cosmos-sdk/x/auth"
+  distr "github.com/cosmos/cosmos-sdk/x/distribution"
+  "github.com/cosmos/cosmos-sdk/x/gov"
+  "github.com/cosmos/cosmos-sdk/x/mint"
+  "github.com/cosmos/cosmos-sdk/x/params"
+  "github.com/cosmos/cosmos-sdk/x/simulation"
+  "github.com/cosmos/cosmos-sdk/x/slashing"
+  "github.com/cosmos/cosmos-sdk/x/staking"
+  "github.com/cosmos/cosmos-sdk/x/supply"
 )
 
 func init() {
-	simapp.GetSimulatorFlags()
+  simapp.GetSimulatorFlags()
 }
 
 type StoreKeysPrefixes struct {
-	A        sdk.StoreKey
-	B        sdk.StoreKey
-	Prefixes [][]byte
+  A        sdk.StoreKey
+  B        sdk.StoreKey
+  Prefixes [][]byte
 }
 
 // fauxMerkleModeOpt returns a BaseApp option to use a dbStoreAdapter instead of
 // an IAVLStore for faster simulation speed.
 func fauxMerkleModeOpt(bapp *baseapp.BaseApp) {
-	bapp.SetFauxMerkleMode()
+  bapp.SetFauxMerkleMode()
 }
 
 // interBlockCacheOpt returns a BaseApp option function that sets the persistent
 // inter-block write-through cache.
 func interBlockCacheOpt() func(*baseapp.BaseApp) {
-	return baseapp.SetInterBlockCache(store.NewCommitKVStoreCacheManager())
+  return baseapp.SetInterBlockCache(store.NewCommitKVStoreCacheManager())
 }
 
 func TestFullAppSimulation(t *testing.T) {
-	config, db, dir, logger, skip, err := simapp.SetupSimulation("leveldb-app-sim", "Simulation")
-	if skip {
-		t.Skip("skipping application simulation")
-	}
-	require.NoError(t, err, "simulation setup failed")
+  config, db, dir, logger, skip, err := simapp.SetupSimulation("leveldb-app-sim", "Simulation")
+  if skip {
+    t.Skip("skipping application simulation")
+  }
+  require.NoError(t, err, "simulation setup failed")
 
-	defer func() {
-		db.Close()
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+  defer func() {
+    db.Close()
+    require.NoError(t, os.RemoveAll(dir))
+  }()
 
-	app := NewInitApp(logger, db, nil, true, simapp.FlagPeriodValue, map[int64]bool{}, fauxMerkleModeOpt)
-	require.Equal(t, appName, app.Name())
+  app := NewInitApp(logger, db, nil, true, simapp.FlagPeriodValue, map[int64]bool{}, fauxMerkleModeOpt)
+  require.Equal(t, appName, app.Name())
 
-	// run randomized simulation
-	_, simParams, simErr := simulation.SimulateFromSeed(
-		t, os.Stdout, app.BaseApp, simapp.AppStateFn(app.Codec(), app.SimulationManager()),
-		simapp.SimulationOperations(app, app.Codec(), config),
-		app.ModuleAccountAddrs(), config,
-	)
+  // run randomized simulation
+  _, simParams, simErr := simulation.SimulateFromSeed(
+    t, os.Stdout, app.BaseApp, simapp.AppStateFn(app.Codec(), app.SimulationManager()),
+    simapp.SimulationOperations(app, app.Codec(), config),
+    app.ModuleAccountAddrs(), config,
+  )
 
-	// export state and simParams before the simulation error is checked
-	err = simapp.CheckExportSimulation(app, config, simParams)
-	require.NoError(t, err)
-	require.NoError(t, simErr)
+  // export state and simParams before the simulation error is checked
+  err = simapp.CheckExportSimulation(app, config, simParams)
+  require.NoError(t, err)
+  require.NoError(t, simErr)
 
-	if config.Commit {
-		simapp.PrintStats(db)
-	}
+  if config.Commit {
+    simapp.PrintStats(db)
+  }
 }
 
 func TestAppImportExport(t *testing.T) {
-	config, db, dir, logger, skip, err := simapp.SetupSimulation("leveldb-app-sim", "Simulation")
-	if skip {
-		t.Skip("skipping application import/export simulation")
-	}
-	require.NoError(t, err, "simulation setup failed")
+  config, db, dir, logger, skip, err := simapp.SetupSimulation("leveldb-app-sim", "Simulation")
+  if skip {
+    t.Skip("skipping application import/export simulation")
+  }
+  require.NoError(t, err, "simulation setup failed")
 
-	defer func() {
-		db.Close()
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+  defer func() {
+    db.Close()
+    require.NoError(t, os.RemoveAll(dir))
+  }()
 
-	app := NewInitApp(logger, db, nil, true, simapp.FlagPeriodValue, map[int64]bool{}, fauxMerkleModeOpt)
-	require.Equal(t, appName, app.Name())
+  app := NewInitApp(logger, db, nil, true, simapp.FlagPeriodValue, map[int64]bool{}, fauxMerkleModeOpt)
+  require.Equal(t, appName, app.Name())
 
-	// Run randomized simulation
-	_, simParams, simErr := simulation.SimulateFromSeed(
-		t, os.Stdout, app.BaseApp, simapp.AppStateFn(app.Codec(), app.SimulationManager()),
-		simapp.SimulationOperations(app, app.Codec(), config),
-		app.ModuleAccountAddrs(), config,
-	)
+  // Run randomized simulation
+  _, simParams, simErr := simulation.SimulateFromSeed(
+    t, os.Stdout, app.BaseApp, simapp.AppStateFn(app.Codec(), app.SimulationManager()),
+    simapp.SimulationOperations(app, app.Codec(), config),
+    app.ModuleAccountAddrs(), config,
+  )
 
-	// export state and simParams before the simulation error is checked
-	err = simapp.CheckExportSimulation(app, config, simParams)
-	require.NoError(t, err)
-	require.NoError(t, simErr)
+  // export state and simParams before the simulation error is checked
+  err = simapp.CheckExportSimulation(app, config, simParams)
+  require.NoError(t, err)
+  require.NoError(t, simErr)
 
-	if config.Commit {
-		simapp.PrintStats(db)
-	}
+  if config.Commit {
+    simapp.PrintStats(db)
+  }
 
-	fmt.Printf("exporting genesis...\n")
+  fmt.Printf("exporting genesis...\n")
 
-	appState, _, err := app.ExportAppStateAndValidators(false, []string{})
-	require.NoError(t, err)
+  appState, _, err := app.ExportAppStateAndValidators(false, []string{})
+  require.NoError(t, err)
 
-	fmt.Printf("importing genesis...\n")
+  fmt.Printf("importing genesis...\n")
 
-	_, newDB, newDir, _, _, err := simapp.SetupSimulation("leveldb-app-sim-2", "Simulation-2")
-	require.NoError(t, err, "simulation setup failed")
+  _, newDB, newDir, _, _, err := simapp.SetupSimulation("leveldb-app-sim-2", "Simulation-2")
+  require.NoError(t, err, "simulation setup failed")
 
-	defer func() {
-		newDB.Close()
-		require.NoError(t, os.RemoveAll(newDir))
-	}()
+  defer func() {
+    newDB.Close()
+    require.NoError(t, os.RemoveAll(newDir))
+  }()
 
-	newApp := NewInitApp(log.NewNopLogger(), newDB, nil, true, simapp.FlagPeriodValue, map[int64]bool{}, fauxMerkleModeOpt)
-	require.Equal(t, appName, newApp.Name())
+  newApp := NewInitApp(log.NewNopLogger(), newDB, nil, true, simapp.FlagPeriodValue, map[int64]bool{}, fauxMerkleModeOpt)
+  require.Equal(t, appName, newApp.Name())
 
-	var genesisState GenesisState
-	err = app.Codec().UnmarshalJSON(appState, &genesisState)
-	require.NoError(t, err)
+  var genesisState GenesisState
+  err = app.Codec().UnmarshalJSON(appState, &genesisState)
+  require.NoError(t, err)
 
-	ctxA := app.NewContext(true, abci.Header{Height: app.LastBlockHeight()})
-	ctxB := newApp.NewContext(true, abci.Header{Height: app.LastBlockHeight()})
-	newApp.mm.InitGenesis(ctxB, genesisState)
+  ctxA := app.NewContext(true, abci.Header{Height: app.LastBlockHeight()})
+  ctxB := newApp.NewContext(true, abci.Header{Height: app.LastBlockHeight()})
+  newApp.mm.InitGenesis(ctxB, genesisState)
 
-	fmt.Printf("comparing stores...\n")
+  fmt.Printf("comparing stores...\n")
 
-	storeKeysPrefixes := []StoreKeysPrefixes{
-		{app.keys[baseapp.MainStoreKey], newApp.keys[baseapp.MainStoreKey], [][]byte{}},
-		{app.keys[auth.StoreKey], newApp.keys[auth.StoreKey], [][]byte{}},
-		{app.keys[staking.StoreKey], newApp.keys[staking.StoreKey],
-			[][]byte{
-				staking.UnbondingQueueKey, staking.RedelegationQueueKey, staking.ValidatorQueueKey,
-			}}, // ordering may change but it doesn't matter
-		{app.keys[slashing.StoreKey], newApp.keys[slashing.StoreKey], [][]byte{}},
-		{app.keys[mint.StoreKey], newApp.keys[mint.StoreKey], [][]byte{}},
-		{app.keys[distr.StoreKey], newApp.keys[distr.StoreKey], [][]byte{}},
-		{app.keys[supply.StoreKey], newApp.keys[supply.StoreKey], [][]byte{}},
-		{app.keys[params.StoreKey], newApp.keys[params.StoreKey], [][]byte{}},
-		{app.keys[gov.StoreKey], newApp.keys[gov.StoreKey], [][]byte{}},
+  storeKeysPrefixes := []StoreKeysPrefixes{
+    {app.keys[baseapp.MainStoreKey], newApp.keys[baseapp.MainStoreKey], [][]byte{}},
+    {app.keys[auth.StoreKey], newApp.keys[auth.StoreKey], [][]byte{}},
+    {app.keys[staking.StoreKey], newApp.keys[staking.StoreKey],
+      [][]byte{
+        staking.UnbondingQueueKey, staking.RedelegationQueueKey, staking.ValidatorQueueKey,
+      }}, // ordering may change but it doesn't matter
+    {app.keys[slashing.StoreKey], newApp.keys[slashing.StoreKey], [][]byte{}},
+    {app.keys[mint.StoreKey], newApp.keys[mint.StoreKey], [][]byte{}},
+    {app.keys[distr.StoreKey], newApp.keys[distr.StoreKey], [][]byte{}},
+    {app.keys[supply.StoreKey], newApp.keys[supply.StoreKey], [][]byte{}},
+    {app.keys[params.StoreKey], newApp.keys[params.StoreKey], [][]byte{}},
+    {app.keys[gov.StoreKey], newApp.keys[gov.StoreKey], [][]byte{}},
     // TODO: Add your module(s)
-	}
+  }
 
-	for _, skp := range storeKeysPrefixes {
-		storeA := ctxA.KVStore(skp.A)
-		storeB := ctxB.KVStore(skp.B)
+  for _, skp := range storeKeysPrefixes {
+    storeA := ctxA.KVStore(skp.A)
+    storeB := ctxB.KVStore(skp.B)
 
-		failedKVAs, failedKVBs := sdk.DiffKVStores(storeA, storeB, skp.Prefixes)
-		require.Equal(t, len(failedKVAs), len(failedKVBs), "unequal sets of key-values to compare")
+    failedKVAs, failedKVBs := sdk.DiffKVStores(storeA, storeB, skp.Prefixes)
+    require.Equal(t, len(failedKVAs), len(failedKVBs), "unequal sets of key-values to compare")
 
-		fmt.Printf("compared %d key/value pairs between %s and %s\n", len(failedKVAs), skp.A, skp.B)
-		require.Equal(t, len(failedKVAs), 0, simapp.GetSimulationLog(skp.A.Name(), app.SimulationManager().StoreDecoders, app.Codec(), failedKVAs, failedKVBs))
-	}
+    fmt.Printf("compared %d key/value pairs between %s and %s\n", len(failedKVAs), skp.A, skp.B)
+    require.Equal(t, len(failedKVAs), 0, simapp.GetSimulationLog(skp.A.Name(), app.SimulationManager().StoreDecoders, app.Codec(), failedKVAs, failedKVBs))
+  }
 }
 
 func TestAppSimulationAfterImport(t *testing.T) {
-	config, db, dir, logger, skip, err := simapp.SetupSimulation("leveldb-app-sim", "Simulation")
-	if skip {
-		t.Skip("skipping application simulation after import")
-	}
-	require.NoError(t, err, "simulation setup failed")
+  config, db, dir, logger, skip, err := simapp.SetupSimulation("leveldb-app-sim", "Simulation")
+  if skip {
+    t.Skip("skipping application simulation after import")
+  }
+  require.NoError(t, err, "simulation setup failed")
 
-	defer func() {
-		db.Close()
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+  defer func() {
+    db.Close()
+    require.NoError(t, os.RemoveAll(dir))
+  }()
 
-	app := NewInitApp(logger, db, nil, true, simapp.FlagPeriodValue, map[int64]bool{}, fauxMerkleModeOpt)
-	require.Equal(t, appName, app.Name())
+  app := NewInitApp(logger, db, nil, true, simapp.FlagPeriodValue, map[int64]bool{}, fauxMerkleModeOpt)
+  require.Equal(t, appName, app.Name())
 
-	// Run randomized simulation
-	stopEarly, simParams, simErr := simulation.SimulateFromSeed(
-		t, os.Stdout, app.BaseApp, simapp.AppStateFn(app.Codec(), app.SimulationManager()),
-		simapp.SimulationOperations(app, app.Codec(), config),
-		app.ModuleAccountAddrs(), config,
-	)
+  // Run randomized simulation
+  stopEarly, simParams, simErr := simulation.SimulateFromSeed(
+    t, os.Stdout, app.BaseApp, simapp.AppStateFn(app.Codec(), app.SimulationManager()),
+    simapp.SimulationOperations(app, app.Codec(), config),
+    app.ModuleAccountAddrs(), config,
+  )
 
-	// export state and simParams before the simulation error is checked
-	err = simapp.CheckExportSimulation(app, config, simParams)
-	require.NoError(t, err)
-	require.NoError(t, simErr)
+  // export state and simParams before the simulation error is checked
+  err = simapp.CheckExportSimulation(app, config, simParams)
+  require.NoError(t, err)
+  require.NoError(t, simErr)
 
-	if config.Commit {
-		simapp.PrintStats(db)
-	}
+  if config.Commit {
+    simapp.PrintStats(db)
+  }
 
-	if stopEarly {
-		fmt.Println("can't export or import a zero-validator genesis, exiting test...")
-		return
-	}
+  if stopEarly {
+    fmt.Println("can't export or import a zero-validator genesis, exiting test...")
+    return
+  }
 
-	fmt.Printf("exporting genesis...\n")
+  fmt.Printf("exporting genesis...\n")
 
-	appState, _, err := app.ExportAppStateAndValidators(true, []string{})
-	require.NoError(t, err)
+  appState, _, err := app.ExportAppStateAndValidators(true, []string{})
+  require.NoError(t, err)
 
-	fmt.Printf("importing genesis...\n")
+  fmt.Printf("importing genesis...\n")
 
-	_, newDB, newDir, _, _, err := simapp.SetupSimulation("leveldb-app-sim-2", "Simulation-2")
-	require.NoError(t, err, "simulation setup failed")
+  _, newDB, newDir, _, _, err := simapp.SetupSimulation("leveldb-app-sim-2", "Simulation-2")
+  require.NoError(t, err, "simulation setup failed")
 
-	defer func() {
-		newDB.Close()
-		require.NoError(t, os.RemoveAll(newDir))
-	}()
+  defer func() {
+    newDB.Close()
+    require.NoError(t, os.RemoveAll(newDir))
+  }()
 
-	newApp := NewInitApp(log.NewNopLogger(), newDB, nil, true, simapp.FlagPeriodValue, map[int64]bool{}, fauxMerkleModeOpt)
-	require.Equal(t, appName, newApp.Name())
+  newApp := NewInitApp(log.NewNopLogger(), newDB, nil, true, simapp.FlagPeriodValue, map[int64]bool{}, fauxMerkleModeOpt)
+  require.Equal(t, appName, newApp.Name())
 
-	newApp.InitChain(abci.RequestInitChain{
-		AppStateBytes: appState,
-	})
+  newApp.InitChain(abci.RequestInitChain{
+    AppStateBytes: appState,
+  })
 
-	_, _, err = simulation.SimulateFromSeed(
-		t, os.Stdout, newApp.BaseApp, simapp.AppStateFn(app.Codec(), app.SimulationManager()),
-		simapp.SimulationOperations(newApp, newApp.Codec(), config),
-		newApp.ModuleAccountAddrs(), config,
-	)
-	require.NoError(t, err)
+  _, _, err = simulation.SimulateFromSeed(
+    t, os.Stdout, newApp.BaseApp, simapp.AppStateFn(app.Codec(), app.SimulationManager()),
+    simapp.SimulationOperations(newApp, newApp.Codec(), config),
+    newApp.ModuleAccountAddrs(), config,
+  )
+  require.NoError(t, err)
 }
 
 func TestAppStateDeterminism(t *testing.T) {
-	if !simapp.FlagEnabledValue {
-		t.Skip("skipping application simulation")
-	}
+  if !simapp.FlagEnabledValue {
+    t.Skip("skipping application simulation")
+  }
 
-	config := simapp.NewConfigFromFlags()
-	config.InitialBlockHeight = 1
-	config.ExportParamsPath = ""
-	config.OnOperation = false
-	config.AllInvariants = false
-	config.ChainID = helpers.SimAppChainID
+  config := simapp.NewConfigFromFlags()
+  config.InitialBlockHeight = 1
+  config.ExportParamsPath = ""
+  config.OnOperation = false
+  config.AllInvariants = false
+  config.ChainID = helpers.SimAppChainID
 
-	numSeeds := 3
-	numTimesToRunPerSeed := 5
-	appHashList := make([]json.RawMessage, numTimesToRunPerSeed)
+  numSeeds := 3
+  numTimesToRunPerSeed := 5
+  appHashList := make([]json.RawMessage, numTimesToRunPerSeed)
 
-	for i := 0; i < numSeeds; i++ {
-		config.Seed = rand.Int63()
+  for i := 0; i < numSeeds; i++ {
+    config.Seed = rand.Int63()
 
-		for j := 0; j < numTimesToRunPerSeed; j++ {
-			var logger log.Logger
-			if simapp.FlagVerboseValue {
-				logger = log.TestingLogger()
-			} else {
-				logger = log.NewNopLogger()
-			}
+    for j := 0; j < numTimesToRunPerSeed; j++ {
+      var logger log.Logger
+      if simapp.FlagVerboseValue {
+        logger = log.TestingLogger()
+      } else {
+        logger = log.NewNopLogger()
+      }
 
-			db := dbm.NewMemDB()
+      db := dbm.NewMemDB()
 
-			app := NewInitApp(logger, db, nil, true, simapp.FlagPeriodValue, map[int64]bool{}, interBlockCacheOpt())
+      app := NewInitApp(logger, db, nil, true, simapp.FlagPeriodValue, map[int64]bool{}, interBlockCacheOpt())
 
-			fmt.Printf(
-				"running non-determinism simulation; seed %d: %d/%d, attempt: %d/%d\n",
-				config.Seed, i+1, numSeeds, j+1, numTimesToRunPerSeed,
-			)
+      fmt.Printf(
+        "running non-determinism simulation; seed %d: %d/%d, attempt: %d/%d\n",
+        config.Seed, i+1, numSeeds, j+1, numTimesToRunPerSeed,
+      )
 
-			_, _, err := simulation.SimulateFromSeed(
-				t, os.Stdout, app.BaseApp, simapp.AppStateFn(app.Codec(), app.SimulationManager()),
-				simapp.SimulationOperations(app, app.Codec(), config),
-				app.ModuleAccountAddrs(), config,
-			)
-			require.NoError(t, err)
+      _, _, err := simulation.SimulateFromSeed(
+        t, os.Stdout, app.BaseApp, simapp.AppStateFn(app.Codec(), app.SimulationManager()),
+        simapp.SimulationOperations(app, app.Codec(), config),
+        app.ModuleAccountAddrs(), config,
+      )
+      require.NoError(t, err)
 
-			if config.Commit {
-				simapp.PrintStats(db)
-			}
+      if config.Commit {
+        simapp.PrintStats(db)
+      }
 
-			appHash := app.LastCommitID().Hash
-			appHashList[j] = appHash
+      appHash := app.LastCommitID().Hash
+      appHashList[j] = appHash
 
-			if j != 0 {
-				require.Equal(
-					t, appHashList[0], appHashList[j],
-					"non-determinism in seed %d: %d/%d, attempt: %d/%d\n", config.Seed, i+1, numSeeds, j+1, numTimesToRunPerSeed,
-				)
-			}
-		}
-	}
+      if j != 0 {
+        require.Equal(
+          t, appHashList[0], appHashList[j],
+          "non-determinism in seed %d: %d/%d, attempt: %d/%d\n", config.Seed, i+1, numSeeds, j+1, numTimesToRunPerSeed,
+        )
+      }
+    }
+  }
 }

--- a/templates/lvl-max/cmd/acli/main.go.tmpl
+++ b/templates/lvl-max/cmd/acli/main.go.tmpl
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/client/keys"
+	"github.com/cosmos/cosmos-sdk/client/lcd"
+	"github.com/cosmos/cosmos-sdk/client/rpc"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/version"
+	"github.com/cosmos/cosmos-sdk/x/auth"
+	authcmd "github.com/cosmos/cosmos-sdk/x/auth/client/cli"
+	authrest "github.com/cosmos/cosmos-sdk/x/auth/client/rest"
+	"github.com/cosmos/cosmos-sdk/x/bank"
+	bankcmd "github.com/cosmos/cosmos-sdk/x/bank/client/cli"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/tendermint/go-amino"
+	"github.com/tendermint/tendermint/libs/cli"
+
+	"github.com/{{ .User }}/{{ .Repo }}/app"
+
+)
+
+func main() {
+	// Configure cobra to sort commands
+	cobra.EnableCommandSorting = false
+
+	// Instantiate the codec for the command line application
+	cdc := app.MakeCodec()
+
+	// Read in the configuration file for the sdk
+	config := sdk.GetConfig()
+	config.SetBech32PrefixForAccount(sdk.Bech32PrefixAccAddr, sdk.Bech32PrefixAccPub)
+	config.SetBech32PrefixForValidator(sdk.Bech32PrefixValAddr, sdk.Bech32PrefixValPub)
+	config.SetBech32PrefixForConsensusNode(sdk.Bech32PrefixConsAddr, sdk.Bech32PrefixConsPub)
+	config.Seal()
+
+	// TODO: setup keybase, viper object, etc. to be passed into
+	// the below functions and eliminate global vars, like we do
+	// with the cdc
+
+	rootCmd := &cobra.Command{
+		Use:   "acli",
+		Short: "Command line interface for interacting with appd",
+	}
+
+	// Add --chain-id to persistent flags and mark it required
+	rootCmd.PersistentFlags().String(flags.FlagChainID, "", "Chain ID of tendermint node")
+	rootCmd.PersistentPreRunE = func(_ *cobra.Command, _ []string) error {
+		return initConfig(rootCmd)
+	}
+
+	// Construct Root Command
+	rootCmd.AddCommand(
+		rpc.StatusCommand(),
+		client.ConfigCmd(app.DefaultCLIHome),
+		queryCmd(cdc),
+		txCmd(cdc),
+		flags.LineBreak,
+		lcd.ServeCommand(cdc, registerRoutes),
+		flags.LineBreak,
+		keys.Commands(),
+		flags.LineBreak,
+		version.Cmd,
+		flags.NewCompletionCmd(rootCmd, true),
+	)
+
+	// Add flags and prefix all env exposed with AA
+	executor := cli.PrepareMainCmd(rootCmd, "AA", app.DefaultCLIHome)
+
+	err := executor.Execute()
+	if err != nil {
+		fmt.Printf("Failed executing CLI command: %s, exiting...\n", err)
+		os.Exit(1)
+	}
+}
+
+func queryCmd(cdc *amino.Codec) *cobra.Command {
+	queryCmd := &cobra.Command{
+		Use:     "query",
+		Aliases: []string{"q"},
+		Short:   "Querying subcommands",
+	}
+
+	queryCmd.AddCommand(
+		authcmd.GetAccountCmd(cdc),
+		flags.LineBreak,
+		rpc.ValidatorCommand(cdc),
+		rpc.BlockCommand(),
+		authcmd.QueryTxsByEventsCmd(cdc),
+		authcmd.QueryTxCmd(cdc),
+		flags.LineBreak,
+	)
+
+	// add modules' query commands
+	app.ModuleBasics.AddQueryCommands(queryCmd, cdc)
+
+	return queryCmd
+}
+
+func txCmd(cdc *amino.Codec) *cobra.Command {
+	txCmd := &cobra.Command{
+		Use:   "tx",
+		Short: "Transactions subcommands",
+	}
+
+	txCmd.AddCommand(
+		bankcmd.SendTxCmd(cdc),
+		flags.LineBreak,
+		authcmd.GetSignCommand(cdc),
+		authcmd.GetMultiSignCommand(cdc),
+		flags.LineBreak,
+		authcmd.GetBroadcastCommand(cdc),
+		authcmd.GetEncodeCommand(cdc),
+		authcmd.GetDecodeCommand(cdc),
+		flags.LineBreak,
+	)
+
+	// add modules' tx commands
+	app.ModuleBasics.AddTxCommands(txCmd, cdc)
+
+	// remove auth and bank commands as they're mounted under the root tx command
+	var cmdsToRemove []*cobra.Command
+
+	for _, cmd := range txCmd.Commands() {
+		if cmd.Use == auth.ModuleName || cmd.Use == bank.ModuleName {
+			cmdsToRemove = append(cmdsToRemove, cmd)
+		}
+	}
+
+	txCmd.RemoveCommand(cmdsToRemove...)
+
+	return txCmd
+}
+
+// registerRoutes registers the routes from the different modules for the LCD.
+// NOTE: details on the routes added for each module are in the module documentation
+// NOTE: If making updates here you also need to update the test helper in client/lcd/test_helper.go
+func registerRoutes(rs *lcd.RestServer) {
+	client.RegisterRoutes(rs.CliCtx, rs.Mux)
+	authrest.RegisterTxRoutes(rs.CliCtx, rs.Mux)
+	app.ModuleBasics.RegisterRESTRoutes(rs.CliCtx, rs.Mux)
+}
+
+func initConfig(cmd *cobra.Command) error {
+	home, err := cmd.PersistentFlags().GetString(cli.HomeFlag)
+	if err != nil {
+		return err
+	}
+
+	cfgFile := path.Join(home, "config", "config.toml")
+	if _, err := os.Stat(cfgFile); err == nil {
+		viper.SetConfigFile(cfgFile)
+
+		if err := viper.ReadInConfig(); err != nil {
+			return err
+		}
+	}
+	if err := viper.BindPFlag(flags.FlagChainID, cmd.PersistentFlags().Lookup(flags.FlagChainID)); err != nil {
+		return err
+	}
+	if err := viper.BindPFlag(cli.EncodingFlag, cmd.PersistentFlags().Lookup(cli.EncodingFlag)); err != nil {
+		return err
+	}
+	return viper.BindPFlag(cli.OutputFlag, cmd.PersistentFlags().Lookup(cli.OutputFlag))
+}

--- a/templates/lvl-max/cmd/aud/genaccounts.go.tmpl
+++ b/templates/lvl-max/cmd/aud/genaccounts.go.tmpl
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/tendermint/tendermint/libs/cli"
+
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/crypto/keys"
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/server"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth"
+	authexported "github.com/cosmos/cosmos-sdk/x/auth/exported"
+	authvesting "github.com/cosmos/cosmos-sdk/x/auth/vesting"
+	"github.com/cosmos/cosmos-sdk/x/genutil"
+)
+
+const (
+	flagClientHome   = "home-client"
+	flagVestingStart = "vesting-start-time"
+	flagVestingEnd   = "vesting-end-time"
+	flagVestingAmt   = "vesting-amount"
+)
+
+// AddGenesisAccountCmd returns add-genesis-account cobra Command.
+func AddGenesisAccountCmd(
+	ctx *server.Context, cdc *codec.Codec, defaultNodeHome, defaultClientHome string,
+) *cobra.Command {
+
+	cmd := &cobra.Command{
+		Use:   "add-genesis-account [address_or_key_name] [coin][,[coin]]",
+		Short: "Add a genesis account to genesis.json",
+		Long: `Add a genesis account to genesis.json. The provided account must specify
+the account address or key name and a list of initial coins. If a key name is given,
+the address will be looked up in the local Keybase. The list of initial tokens must
+contain valid denominations. Accounts may optionally be supplied with vesting parameters.
+`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			config := ctx.Config
+			config.SetRoot(viper.GetString(cli.HomeFlag))
+
+			addr, err := sdk.AccAddressFromBech32(args[0])
+			inBuf := bufio.NewReader(cmd.InOrStdin())
+			if err != nil {
+				// attempt to lookup address from Keybase if no address was provided
+				kb, err := keys.NewKeyring(
+					sdk.KeyringServiceName(),
+					viper.GetString(flags.FlagKeyringBackend),
+					viper.GetString(flagClientHome),
+					inBuf,
+				)
+				if err != nil {
+					return err
+				}
+
+				info, err := kb.Get(args[0])
+				if err != nil {
+					return fmt.Errorf("failed to get address from Keybase: %w", err)
+				}
+
+				addr = info.GetAddress()
+			}
+
+			coins, err := sdk.ParseCoins(args[1])
+			if err != nil {
+				return fmt.Errorf("failed to parse coins: %w", err)
+			}
+
+			vestingStart := viper.GetInt64(flagVestingStart)
+			vestingEnd := viper.GetInt64(flagVestingEnd)
+			vestingAmt, err := sdk.ParseCoins(viper.GetString(flagVestingAmt))
+			if err != nil {
+				return fmt.Errorf("failed to parse vesting amount: %w", err)
+			}
+
+			// create concrete account type based on input parameters
+			var genAccount authexported.GenesisAccount
+
+			baseAccount := auth.NewBaseAccount(addr, coins.Sort(), nil, 0, 0)
+			if !vestingAmt.IsZero() {
+				baseVestingAccount, err := authvesting.NewBaseVestingAccount(baseAccount, vestingAmt.Sort(), vestingEnd)
+				if err != nil {
+					return fmt.Errorf("failed to create base vesting account: %w", err)
+				}
+
+				switch {
+				case vestingStart != 0 && vestingEnd != 0:
+					genAccount = authvesting.NewContinuousVestingAccountRaw(baseVestingAccount, vestingStart)
+
+				case vestingEnd != 0:
+					genAccount = authvesting.NewDelayedVestingAccountRaw(baseVestingAccount)
+
+				default:
+					return errors.New("invalid vesting parameters; must supply start and end time or end time")
+				}
+			} else {
+				genAccount = baseAccount
+			}
+
+			if err := genAccount.Validate(); err != nil {
+				return fmt.Errorf("failed to validate new genesis account: %w", err)
+			}
+
+			genFile := config.GenesisFile()
+			appState, genDoc, err := genutil.GenesisStateFromGenFile(cdc, genFile)
+			if err != nil {
+				return fmt.Errorf("failed to unmarshal genesis state: %w", err)
+			}
+
+			authGenState := auth.GetGenesisStateFromAppState(cdc, appState)
+
+			if authGenState.Accounts.Contains(addr) {
+				return fmt.Errorf("cannot add account at existing address %s", addr)
+			}
+
+			// Add the new account to the set of genesis accounts and sanitize the
+			// accounts afterwards.
+			authGenState.Accounts = append(authGenState.Accounts, genAccount)
+			authGenState.Accounts = auth.SanitizeGenesisAccounts(authGenState.Accounts)
+
+			authGenStateBz, err := cdc.MarshalJSON(authGenState)
+			if err != nil {
+				return fmt.Errorf("failed to marshal auth genesis state: %w", err)
+			}
+
+			appState[auth.ModuleName] = authGenStateBz
+
+			appStateJSON, err := cdc.MarshalJSON(appState)
+			if err != nil {
+				return fmt.Errorf("failed to marshal application genesis state: %w", err)
+			}
+
+			genDoc.AppState = appStateJSON
+			return genutil.ExportGenesisFile(genDoc, genFile)
+		},
+	}
+
+	cmd.Flags().String(cli.HomeFlag, defaultNodeHome, "node's home directory")
+	cmd.Flags().String(flags.FlagKeyringBackend, flags.DefaultKeyringBackend, "Select keyring's backend (os|file|test)")
+	cmd.Flags().String(flagClientHome, defaultClientHome, "client's home directory")
+	cmd.Flags().String(flagVestingAmt, "", "amount of coins for vesting accounts")
+	cmd.Flags().Uint64(flagVestingStart, 0, "schedule start time (unix epoch) for vesting accounts")
+	cmd.Flags().Uint64(flagVestingEnd, 0, "schedule end time (unix epoch) for vesting accounts")
+
+	return cmd
+}

--- a/templates/lvl-max/cmd/aud/main.go.tmpl
+++ b/templates/lvl-max/cmd/aud/main.go.tmpl
@@ -80,8 +80,13 @@ func newApp(logger log.Logger, db dbm.DB, traceStore io.Writer) abci.Application
 		cache = store.NewCommitKVStoreCacheManager()
 	}
 
+  skipUpgradeHeights := make(map[int64]bool)
+	for _, h := range viper.GetIntSlice(server.FlagUnsafeSkipUpgrades) {
+		skipUpgradeHeights[int64(h)] = true
+	}
+
 	return app.NewInitApp(
-		logger, db, traceStore, true, invCheckPeriod,
+		logger, db, traceStore, true, invCheckPeriod, skipUpgradeHeights,
 		baseapp.SetPruning(store.NewPruningOptionsFromString(viper.GetString("pruning"))),
 		baseapp.SetMinGasPrices(viper.GetString(server.FlagMinGasPrices)),
 		baseapp.SetHaltHeight(viper.GetUint64(server.FlagHaltHeight)),
@@ -95,7 +100,7 @@ func exportAppStateAndTMValidators(
 ) (json.RawMessage, []tmtypes.GenesisValidator, error) {
 
 	if height != -1 {
-		aApp := app.NewInitApp(logger, db, traceStore, false, uint(1))
+		aApp := app.NewInitApp(logger, db, traceStore, false, uint(1), map[int64]bool{})
 		err := aApp.LoadHeight(height)
 		if err != nil {
 			return nil, nil, err
@@ -103,7 +108,7 @@ func exportAppStateAndTMValidators(
 		return aApp.ExportAppStateAndValidators(forZeroHeight, jailWhiteList)
 	}
 
-	aApp := app.NewInitApp(logger, db, traceStore, true, uint(1))
+	aApp := app.NewInitApp(logger, db, traceStore, true, uint(1), map[int64]bool{})
 
 	return aApp.ExportAppStateAndValidators(forZeroHeight, jailWhiteList)
 }

--- a/templates/lvl-max/cmd/aud/main.go.tmpl
+++ b/templates/lvl-max/cmd/aud/main.go.tmpl
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/libs/cli"
+	"github.com/tendermint/tendermint/libs/log"
+	tmtypes "github.com/tendermint/tendermint/types"
+	dbm "github.com/tendermint/tm-db"
+
+	"github.com/{{ .User }}/{{ .Repo }}/app"
+
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	"github.com/cosmos/cosmos-sdk/client/debug"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/server"
+	"github.com/cosmos/cosmos-sdk/store"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth"
+	genutilcli "github.com/cosmos/cosmos-sdk/x/genutil/client/cli"
+	"github.com/cosmos/cosmos-sdk/x/staking"
+)
+
+const flagInvCheckPeriod = "inv-check-period"
+
+var invCheckPeriod uint
+
+func main() {
+	cdc := app.MakeCodec()
+
+	config := sdk.GetConfig()
+	config.SetBech32PrefixForAccount(sdk.Bech32PrefixAccAddr, sdk.Bech32PrefixAccPub)
+	config.SetBech32PrefixForValidator(sdk.Bech32PrefixValAddr, sdk.Bech32PrefixValPub)
+	config.SetBech32PrefixForConsensusNode(sdk.Bech32PrefixConsAddr, sdk.Bech32PrefixConsPub)
+	config.Seal()
+
+	ctx := server.NewDefaultContext()
+	cobra.EnableCommandSorting = false
+	rootCmd := &cobra.Command{
+		Use:               "aud",
+		Short:             "app Daemon (server)",
+		PersistentPreRunE: server.PersistentPreRunEFn(ctx),
+	}
+
+	rootCmd.AddCommand(genutilcli.InitCmd(ctx, cdc, app.ModuleBasics, app.DefaultNodeHome))
+	rootCmd.AddCommand(genutilcli.CollectGenTxsCmd(ctx, cdc, auth.GenesisAccountIterator{}, app.DefaultNodeHome))
+	rootCmd.AddCommand(genutilcli.MigrateGenesisCmd(ctx, cdc))
+	rootCmd.AddCommand(
+		genutilcli.GenTxCmd(
+			ctx, cdc, app.ModuleBasics, staking.AppModuleBasic{},
+			auth.GenesisAccountIterator{}, app.DefaultNodeHome, app.DefaultCLIHome,
+		),
+	)
+	rootCmd.AddCommand(genutilcli.ValidateGenesisCmd(ctx, cdc, app.ModuleBasics))
+	rootCmd.AddCommand(AddGenesisAccountCmd(ctx, cdc, app.DefaultNodeHome, app.DefaultCLIHome))
+	rootCmd.AddCommand(flags.NewCompletionCmd(rootCmd, true))
+	rootCmd.AddCommand(debug.Cmd(cdc))
+
+	server.AddCommands(ctx, cdc, rootCmd, newApp, exportAppStateAndTMValidators)
+
+	// prepare and add flags
+	executor := cli.PrepareBaseCmd(rootCmd, "AU", app.DefaultNodeHome)
+	rootCmd.PersistentFlags().UintVar(&invCheckPeriod, flagInvCheckPeriod,
+		0, "Assert registered invariants every N blocks")
+	err := executor.Execute()
+	if err != nil {
+		panic(err)
+	}
+}
+
+func newApp(logger log.Logger, db dbm.DB, traceStore io.Writer) abci.Application {
+	var cache sdk.MultiStorePersistentCache
+
+	if viper.GetBool(server.FlagInterBlockCache) {
+		cache = store.NewCommitKVStoreCacheManager()
+	}
+
+	return app.NewInitApp(
+		logger, db, traceStore, true, invCheckPeriod,
+		baseapp.SetPruning(store.NewPruningOptionsFromString(viper.GetString("pruning"))),
+		baseapp.SetMinGasPrices(viper.GetString(server.FlagMinGasPrices)),
+		baseapp.SetHaltHeight(viper.GetUint64(server.FlagHaltHeight)),
+		baseapp.SetHaltTime(viper.GetUint64(server.FlagHaltTime)),
+		baseapp.SetInterBlockCache(cache),
+	)
+}
+
+func exportAppStateAndTMValidators(
+	logger log.Logger, db dbm.DB, traceStore io.Writer, height int64, forZeroHeight bool, jailWhiteList []string,
+) (json.RawMessage, []tmtypes.GenesisValidator, error) {
+
+	if height != -1 {
+		aApp := app.NewInitApp(logger, db, traceStore, false, uint(1))
+		err := aApp.LoadHeight(height)
+		if err != nil {
+			return nil, nil, err
+		}
+		return aApp.ExportAppStateAndValidators(forZeroHeight, jailWhiteList)
+	}
+
+	aApp := app.NewInitApp(logger, db, traceStore, true, uint(1))
+
+	return aApp.ExportAppStateAndValidators(forZeroHeight, jailWhiteList)
+}

--- a/templates/lvl-max/go.mod.tmpl
+++ b/templates/lvl-max/go.mod.tmpl
@@ -1,0 +1,21 @@
+module github.com/{{ .User }}/{{ .Repo }}
+
+go 1.13
+
+require (
+	github.com/btcsuite/btcd v0.0.0-20190807005414-4063feeff79a // indirect
+	github.com/cosmos/cosmos-sdk v0.38.0
+	github.com/golang/mock v1.3.1 // indirect
+	github.com/onsi/ginkgo v1.8.0 // indirect
+	github.com/onsi/gomega v1.5.0 // indirect
+	github.com/prometheus/client_golang v1.1.0 // indirect
+	github.com/rcrowley/go-metrics v0.0.0-20190706150252-9beb055b7962 // indirect
+	github.com/spf13/afero v1.2.2 // indirect
+	github.com/spf13/cobra v0.0.5
+	github.com/spf13/viper v1.6.2
+	github.com/tendermint/go-amino v0.15.1
+	github.com/tendermint/tendermint v0.33.0
+	github.com/tendermint/tm-db v0.4.0
+	golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297 // indirect
+	golang.org/x/text v0.3.2 // indirect
+)


### PR DESCRIPTION
I created `lvl-max` which is a template uses all modules in `cosmos-sdk`.
In concrete, `crisis`, `mint`, `gov`, `evidence`, `upgrade`.
The order of modules in code is referred to the codes of `gaia`.

I already checked that the code created by `lvl-max` scaffold can be compiled.

I think that the name `lvl-max` should be changed properly, but I would appreciate if this PR is accepted because I just want fully module using template.

Thanks
Kimura Yu (LCNEM, Inc. Japanese leading cosmos community company)