### PR TITLE
Add missing slashing.NewAppModule to app.go.tmpl in lvl-1

### DIFF
--- a/templates/lvl-1/app/app.go.tmpl
+++ b/templates/lvl-1/app/app.go.tmpl
@@ -216,6 +216,7 @@ func NewInitApp(
 		bank.NewAppModule(app.bankKeeper, app.accountKeeper),
 		supply.NewAppModule(app.supplyKeeper, app.accountKeeper),
 		distr.NewAppModule(app.distrKeeper, app.accountKeeper, app.supplyKeeper, app.stakingKeeper),
+		slashing.NewAppModule(app.slashingKeeper, app.accountKeeper, app.stakingKeeper),
 		// TODO: Add your module(s)
 		staking.NewAppModule(app.stakingKeeper, app.accountKeeper, app.supplyKeeper),
 	)


### PR DESCRIPTION
Add back the initialisation of the slashing module.
It has been removed in the "v0.38.0 update" commit: https://github.com/cosmos/scaffold/commit/ef44fb2f3467339a380f992db4bb366f5f40838d#r37146047

It's causing a nil pointer error in `github.com/cosmos/cosmos-sdk/types/module/module.go` function `(m *Manager) InitGenesis`